### PR TITLE
Include GitHub Issues as an option for feedback

### DIFF
--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -13,7 +13,7 @@ This book is mostly intended for coders. If you can use a programming language, 
 
 === Early-Release Note
 
-The early release version of the book is a *raw and rough draft* and will change regularly. New chapters will be added as they are drafted and there will be plenty of changes to the content, examples and diagrams. There will be factual and technical errors in the early release and some of the examples may not work or refer to obsolete versions of the code. Nevertheless, I hope you will enjoy the content and find it useful. I also hope that you will take the opportunity to "fork" the source code of the book and provide feedback by creating a pull request or submitting a patch. I present this work in the spirit of Cunningham's Law, named after the inventor of the wiki, Ward Cunningham:
+The early release version of the book is a *raw and rough draft* and will change regularly. New chapters will be added as they are drafted and there will be plenty of changes to the content, examples and diagrams. There will be factual and technical errors in the early release and some of the examples may not work or refer to obsolete versions of the code. Nevertheless, I hope you will enjoy the content and find it useful. I also hope that you will take the opportunity to provide feedback by https://github.com/aantonop/bitcoinbook/issues[adding an issue] or proposing a change directly by https://help.github.com/articles/using-pull-requests[creating a pull request]. I present this work in the spirit of Cunningham's Law, named after the inventor of the wiki, Ward Cunningham:
 
 _The best way to get the right answer on the Internet is not to ask a question, it's to post the wrong answer_
 


### PR DESCRIPTION
In addition to encouraging pull requests, also suggest that users create
issues for items they encounter that they do not have the time or
wherewithal to propose a fix for themselves.

This would require that GitHub Issues be enabled on the bitcoinbook
repository; at present they are not.

Note that this change introduces inline links for convenience and
readability with the expectation that the affected section ("Early
Release Notes") will be removed before going to press.
