### PR TITLE
Add 'approximately' disclaimer to 21,000,000

### DIFF
--- a/ch02.asciidoc
+++ b/ch02.asciidoc
@@ -69,7 +69,7 @@ In the following sections we will examine this transaction in more detail, see h
 
 [NOTE]
 ====
-The bitcoin network can transact in fractional values, e.g. from millibitcoins (1/1000th of a bitcoin) down to 1/100,000,000th of a bitcoin, which is known as a Satoshi.  Throughout this book we’ll use the term “bitcoins” to refer to any quantity of bitcoin currency, from the smallest unit (1 Satoshi) to the total number (21,000,000) of all bitcoins that will ever be mined. 
+The bitcoin network can transact in fractional values, e.g. from millibitcoins (1/1000th of a bitcoin) down to 1/100,000,000th of a bitcoin, which is known as a Satoshi.  Throughout this book we’ll use the term “bitcoins” to refer to any quantity of bitcoin currency, from the smallest unit (1 Satoshi) to the total number (approximately 21,000,000) of all bitcoins that will ever be mined. 
 ====
 
 


### PR DESCRIPTION
The exact number of BTC when minting ends is 20999999.9769. Closes issue #26.
