### PR TITLE
Dont use github link to line number

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -71,8 +71,8 @@ The first block in the blockchain is called the _genesis block_ and was created 
 
 Every node always starts with a blockchain of at least one block because the genesis block is statically encoded within the bitcoin client software, such that it cannot be altered. Every node always "knows" the genesis block's hash and structure, the fixed time it was created and even the single transaction within. Thus, every node has the starting point for the blockchain, a secure "root" from which to build a trusted blockchain. 
 
-See the statically encoded genesis block inside the Bitcoin Core client, in chainparams.cpp, line 123:
-https://github.com/bitcoin/bitcoin/blob/master/src/chainparams.cpp#L123
+See the statically encoded genesis block inside the Bitcoin Core client, in chainparams.cpp:
+https://github.com/bitcoin/bitcoin/blob/3955c3940eff83518c186facfec6f50545b5aab5/src/chainparams.cpp#L123
 
 The genesis block has the identifier hash +000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f+. You can search for that block hash in any block explorer website, such as blockchain.info, and you will find a page describing the contents of this block, with a URL containing that hash:
 


### PR DESCRIPTION
If any line above the linked line is ever added or removed from
chainparams.cpp, the link pointing to L.123 will continue to point to
L.123 but the start of the comment won't be there. See
andrew.yurisich.com/work/2014/07/16/dont-link-that-line-number/ for the
workaround i have used on this.
