### PR TITLE
Reworked and added additional information on Namecoin's namespecs.

### DIFF
--- a/ch09.asciidoc
+++ b/ch09.asciidoc
@@ -283,10 +283,11 @@ Namecoin's basic parameters are the same as bitcoin's:
 * Consensus algorithm: SHA256 Proof-of-Work
 * Market capitalization: $10 million USD in Summer 2014
 
-Namecoin currently has two namespaces:
+Namecoin's namespaces are not restricted, and anyone can use any namespace in any way. However, certain namespaces have an agreed upon specification so that when it is read from the blockchain, software knows how to read and proceed from there. If it is malformed, then whatever software you used to read from the specific namespace will throw an error. Some of the popular namespaces are:
 
 * +d/+ is the domain-name namespace for +.bit+ domains
 * +id/+ is the namespace for storing person identifiers such as email addresses, PGP keys etc.
+* +u/+ is an additional, more structured specfication to store identities (based on openspecs).
 
 The Namecoin client is very similar to Bitcoin Core, as it is derived from the same source code. Upon installation, the client will download a full copy of the namecoin blockchain and then will be ready to query and register names. There are three main commands: 
 


### PR DESCRIPTION
Namecoin's namespaces aren't set in stone. The first specs were d & id. However, for example, onename is building on a more structured identity namespace (https://github.com/opennamesystem/openspecs) on u/ (which has recently become popular).
