### PR TITLE
fix typo ref to file in bitcoin core project

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -88,7 +88,7 @@ $
 ----
 
 
-The source code includes documentation, which can be found in a number of files. Review the main documentation located in README.md in the bitcoin directory by typing +more README.md+ at the prompt and using the space bar to progress to the next page. In this chapter we will build the command-line bitcoin client, also known as +bitcoind+ on Linux. Review the instructions for compiling the bitcoind command-line client on your platform by typing +more doc/build-unix.md+. Alternative instructions for Mac OSX and Windows can be found in the doc directory, as +build-os.md+ or +build-msw.md+ respectively. 
+The source code includes documentation, which can be found in a number of files. Review the main documentation located in README.md in the bitcoin directory by typing +more README.md+ at the prompt and using the space bar to progress to the next page. In this chapter we will build the command-line bitcoin client, also known as +bitcoind+ on Linux. Review the instructions for compiling the bitcoind command-line client on your platform by typing +more doc/build-unix.md+. Alternative instructions for Mac OSX and Windows can be found in the doc directory, as +build-osx.md+ or +build-msw.md+ respectively. 
 
 Carefully review the build pre-requisites which are in the first part of the build documentation. These are libraries that must be present on your system before you can begin to compile bitcoin. If these pre-requisites are missing the build process will fail with an error. If this happens because you missed a pre-requisite, you can install it and then resume the build process from where you left off. Assuming the pre-requisites are installed, we start the build process by generating a set of build scripts using the +autogen.sh+ script.
 


### PR DESCRIPTION
Paragraph refers to mac documentation file of bitcoin/bitcoin as build-os.md
Correct file is build-osx.md
https://github.com/bitcoin/bitcoin/blob/master/doc/build-osx.md
