### PR TITLE
"merkle tree is a binary tree" does not automatically imply...

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -171,7 +171,7 @@ The process continues until there is only one node at the top, the node known as
 .Calculating the nodes in a Merkle Tree
 image::images/MerkleTree.png["merkle_tree"]
 
-Since the merkle tree is a binary tree, it needs an even number of leaf nodes. If there is an odd number of transactions to summarize, the last transaction hash will be duplicated to create an even number of leaf nodes, also known as a _balanced tree_. This is shown in the example below, where transaction C is duplicated:
+If there is an odd number of transactions to summarize, the last transaction hash will be duplicated to create an even number of leaf nodes, also known as a _balanced tree_. This is shown in the example below, where transaction C is duplicated:
 
 [[merkle_tree_odd]]
 .An even number of data elements, by duplicating one data element


### PR DESCRIPTION
... that it "needs an even number of leaf nodes". Valid binary trees may contain an odd number of leaf nodes.
