### PR TITLE
Fix typo

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -13,7 +13,7 @@ image::images/bitcoin-choose-client.png["bitcoin choose client"]
 
 ==== Running Bitcoin Core for the first time
 
-If you download an installable package, such as an EXE, DMG or PPA, you can install it the same way as any application on your operating system. For Windows, run the EXE and follow the step-by-step instructions. For Mac OS, launch the DMG and drag the Bitcoin-QT icon into your Applications folder. For Ubuntu, double-click on the PPA in your File Explorer and it will open the package manager to install the package. Once you have completed installation you should have a new application "Bitcoin-Qt" in your application list. Double-click on the icon to start the bitcoin client. 
+If you download an installable package, such as an EXE, DMG or PPA, you can install it the same way as any application on your operating system. For Windows, run the EXE and follow the step-by-step instructions. For Mac OS, launch the DMG and drag the Bitcoin-Qt icon into your Applications folder. For Ubuntu, double-click on the PPA in your File Explorer and it will open the package manager to install the package. Once you have completed installation you should have a new application "Bitcoin-Qt" in your application list. Double-click on the icon to start the bitcoin client. 
 
 The first time you run Bitcoin Core it will start downloading the blockchain, a process that may take several days. Leave it running in the background until it displays "Synchronized" and no longer shows "Out of sync" next to the balance.
 


### PR DESCRIPTION
- Renames Bitcoin-QT to Bitcoin-Qt.

Qt is the proper name for the Qt toolkit.

http://en.wikipedia.org/wiki/Qt_%28software%29

QT is an acronym for QuickTime. :-)
