### PR TITLE
Refine Mastercoin information and fix symbol "MSC"

### DIFF
--- a/ch09.asciidoc
+++ b/ch09.asciidoc
@@ -61,7 +61,7 @@ To demonstrate the use of colored coins, we have created a set of 20 colored coi
 
 ==== Mastercoin
 
-Mastercoin is a protocol layer on top of bitcoin that supports a platform for various applications extending the bitcoin system. Mastercoin uses the currency MST as a token for conducting Mastercoin transactions but it is not primarily a currency. Rather it is a platform for building other things, such as user currencies, smart property tokens, de-centralized asset exchanges, contracts, etc. Think of Mastercoin as an application-layer protocol on top of bitcoin's financial transaction transport-layer, just like HTTP runs on top of TCP. 
+Mastercoin is a protocol layer on top of bitcoin that supports a platform for various applications extending the bitcoin system. Mastercoin uses the currency MSC as a token for conducting Mastercoin transactions but it is not primarily a currency. Rather it is a platform for building other things, such as user currencies, smart property tokens, de-centralized asset exchanges, contracts, etc. Think of Mastercoin as an application-layer protocol on top of bitcoin's financial transaction transport-layer, just like HTTP runs on top of TCP. 
 
 Mastercoin operates primarily through transactions sent to and from a special bitcoin address called the "exodus" address (+1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P+), just like HTTP uses a specific TCP port (port 80) to differentiate its traffic from the rest of the TCP traffic. The Mastercoin protocol is gradually transitioning from using the specialized exodus address and multi-signatures to using the OP_RETURN bitcoin operator to encode transaction metadata.
 

--- a/ch09.asciidoc
+++ b/ch09.asciidoc
@@ -61,9 +61,9 @@ To demonstrate the use of colored coins, we have created a set of 20 colored coi
 
 ==== Mastercoin
 
-Mastercoin is a protocol layer on top of bitcoin that supports a platform for various applications extending the bitcoin system. Mastercoin uses the currency MSC as a token for conducting Mastercoin transactions but it is not primarily a currency. Rather it is a platform for building other things, such as user currencies, smart property tokens, de-centralized asset exchanges, contracts, etc. Think of Mastercoin as an application-layer protocol on top of bitcoin's financial transaction transport-layer, just like HTTP runs on top of TCP. 
+Mastercoin is a protocol layer on top of bitcoin that supports a platform for various applications extending the bitcoin system. Mastercoin uses the currency MSC as primary token on the meta-layer. Rather it is a platform for building other things, such as user currencies, smart property tokens, de-centralized asset exchanges, contracts, etc. Think of Mastercoin as an application-layer protocol on top of bitcoin's financial transaction transport-layer, just like HTTP runs on top of TCP. 
 
-Mastercoin operates primarily through transactions sent to and from a special bitcoin address called the "exodus" address (+1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P+), just like HTTP uses a specific TCP port (port 80) to differentiate its traffic from the rest of the TCP traffic. The Mastercoin protocol is gradually transitioning from using the specialized exodus address and multi-signatures to using the OP_RETURN bitcoin operator to encode transaction metadata.
+Mastercoin transactions are primarily identifiable by transactions sent to a special bitcoin address called the "Exodus" address (+1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P+), just like HTTP uses a specific TCP port (port 80) to differentiate its traffic from the rest of the TCP traffic. The Mastercoin protocol is gradually transitioning from embedding obfuscated data in pay-to-public-key-hash and multi-signature scripts to using the OP_RETURN bitcoin operator to encode transaction metadata.
 
 ==== Counterparty
 


### PR DESCRIPTION
The symbol used to represent Mastercoins is "MSC".

Source:
https://github.com/mastercoin-MSC/spec#master-protocol--mastercoin-terminology

A reference to the "Exodus" address is not limited to Mastercoins (as token), but used protocol wide as transaction marker at this point. This PR is furthermore intended as a refinement of Mastercoin's encoding schemes.

Source:
https://github.com/mastercoin-MSC/spec#class-a-transactions-also-known-as-the-original-method
https://github.com/mastercoin-MSC/spec#class-b-transactions-also-known-as-the-multisig-method
