### PR TITLE
getblockhash parameter mistake in example

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -798,7 +798,7 @@ We can also retrieve a block by its block height using the +getblockhash+ comman
 
 ++++
 <screen>
-$ bitcoin-cli getblockhash 0000000000019d6689c085ae165831e934ff763ae46a2a6c17<?pdf-cr?>2b3f1b60a8ce26f
+$ bitcoin-cli getblockhash 0
 </screen>
 ++++
 


### PR DESCRIPTION
getblockhash example should have parameter of height 0 instead of block hash
