### PR TITLE
Update btcd GitHub repository

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -1234,14 +1234,14 @@ One key difference between btcd and bitcoind is that btcd does not include walle
 
 
 ----
-$ go get github.com/conformal/btcd/...
+$ go get github.com/btcsuite/btcd/...
 ----
 
 To update btcd to the latest version, just run:
 
 
 ----
-$ go get -u -v github.com/conformal/btcd/...
+$ go get -u -v github.com/btcsuite/btcd/...
 ----
 
 ===== Controlling btcd


### PR DESCRIPTION
btcd code repository in github moved from conformal to btcsuite, check:
github.com/conformal/btcd
github.com/btcsuite/btcd
