### PR TITLE
Fixes a typo on ch05.asciidoc hex

### DIFF
--- a/ch05.asciidoc
+++ b/ch05.asciidoc
@@ -467,7 +467,7 @@ In version 0.9 of the Bitcoin Core client, a compromise was reached with the int
 OP_RETURN <data>
 ----
 
-The data portion is limited to 80 bytes and most often represents a hash, such as the output from the SHA256 algorithm (32 bytes). Many applications put a prefix in front of the data to help identify the application. For example, the http://proofofexistence.com[Proof of Existence] digital notarization service uses the 8-byte prefix "DOCPROOF," which is ASCII encoded as +44f4350524f4f46+ in hexadecimal.
+The data portion is limited to 80 bytes and most often represents a hash, such as the output from the SHA256 algorithm (32 bytes). Many applications put a prefix in front of the data to help identify the application. For example, the http://proofofexistence.com[Proof of Existence] digital notarization service uses the 8-byte prefix "DOCPROOF", which is ASCII encoded as +444f4350524f4f46+ in hexadecimal.
 
 Keep in mind that there is no "unlocking script" that corresponds to +OP_RETURN+ that could possibly be used to "spend" an +OP_RETURN+ output. The whole point of +OP_RETURN+ is that you can't spend the money locked in that output, and therefore it does not need to be held in the UTXO set as potentially spendable—+OP_RETURN+ is _provably un-spendable_. +OP_RETURN+ is usually an output with a zero bitcoin amount, because any bitcoin assigned to such an output is effectively lost forever. If an +OP_RETURN+ is encountered by the script validation software, it results immediately in halting the execution of the validation script and marking the transaction as invalid. Thus, if you accidentally reference an +OP_RETURN+ output as an input in a transaction, that transaction is invalid. 
 


### PR DESCRIPTION
It's probably just a typo...
The changes:

I changed "DOCPROOF," to just "DOCPROOF" with the comma after quotation mark and its hex from "0x44f4350524f4f46" to "0x444f4350524f4f46"
