### PR TITLE
P2PKH image was incorrectly in the P2PK section

### DIFF
--- a/ch05.asciidoc
+++ b/ch05.asciidoc
@@ -383,6 +383,9 @@ Figures pass:[<xref linkend="P2PubKHash1" xrefstyle="select: labelnumber"/>] and
 .Evaluating a script for a P2PKH transaction (Part 1 of 2)
 image::images/msbt_0503.png["Tx_Script_P2PubKeyHash_1"]
 
+[[P2PubKHash2]]
+.Evaluating a script for a P2PKH transaction (Part 2 of 2)
+image::images/msbt_0504.png["Tx_Script_P2PubKeyHash_2"]
 
 [[p2pk]]    
 ==== Pay-to-Public-Key
@@ -408,10 +411,6 @@ The combined script, which is validated by the transaction validation software, 
 ----
 
 This script is a simple invocation of the +CHECKSIG+ operator, which validates the signature as belonging to the correct key and returns TRUE on the stack.
-
-[[P2PubKHash2]]
-.Evaluating a script for a P2PKH transaction (Part 2 of 2)
-image::images/msbt_0504.png["Tx_Script_P2PubKeyHash_2"]
 
 [[multisig]]
 ==== Multi-Signature


### PR DESCRIPTION
There was a 2-part P2PKH figure.  The first part was in the P2PKH section, but the 2nd part was in the P2PK section.  I just moved the 2nd part of the figure up into the right section.
