### PR TITLE
Update ch06-orig.asciidoc

### DIFF
--- a/ch06-orig.asciidoc
+++ b/ch06-orig.asciidoc
@@ -289,7 +289,7 @@ The client software version that this alert applies to
 Priority::
 An alert priority level, currently unused
 
-Alerts are cryptographically signed by a public key. The corresponding private key is held by a few select members of the core development team. The digital signature ensures that fake alerts will not be propagated on the network.
+Alerts are cryptographically signed with a private key that is held by a few select members of the core development team. The digital signature ensures that fake alerts will not be propagated on the network.
 
 Each node receiving this alert message will verify it, check for expiration, and propagate it to all its peers, thus ensuring rapid propagation across the entire network. In addition to propagating the alert, the nodes might implement a user interface function to present the alert to the user. 
 


### PR DESCRIPTION
Fix 

Alerts are cryptographically signed by a public key. The corresponding private key is held by a few select members of the core development team. The digital signature ensures that fake alerts will not be propagated on the network.

Signatures are not done with public keys.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bitcoinbook/bitcoinbook/191)

<!-- Reviewable:end -->
