### PR TITLE
Fixing satoshi_whitepaper appendix id.

### DIFF
--- a/appdx-bitcoinwhitepaper.asciidoc
+++ b/appdx-bitcoinwhitepaper.asciidoc
@@ -1,4 +1,4 @@
-[[appdxbitcoinimpproposals]]
+[[satoshi_whitepaper]]
 [appendix]
 == Bitcoin - A Peer-to-Peer Electronic Cash System
 


### PR DESCRIPTION
Looks like this ID was accidentally copy/pasted from [appdx-bips.asciidoc](/bitcoinbook/bitcoinbook/blame/develop/appdx-bips.asciidoc#L1)