### PR TITLE
Fixing book.asciidoc file includes to match actual file names.

### DIFF
--- a/book.asciidoc
+++ b/book.asciidoc
@@ -2,7 +2,7 @@
 
 = Mastering Bitcoin
 
-include::praise.asciidoc[]
+include::praise.html[]
 
 include::preface.asciidoc[]
 
@@ -18,15 +18,15 @@ include::ch04.asciidoc[]
 
 include::ch05.asciidoc[]
 
-include::ch06.asciidoc[]
+include::ch06-orig.asciidoc[]
 
-include::ch07.asciidoc[]
+include::ch07-orig.asciidoc[]
 
-include::ch08.asciidoc[]
+include::ch08-orig.asciidoc[]
 
-include::ch09.asciidoc[]
+include::ch09-orig.asciidoc[]
 
-include::ch10.asciidoc[]
+include::ch10-orig.asciidoc[]
 
 include::appdx-bitcoinwhitepaper.asciidoc[]
 
@@ -38,6 +38,6 @@ include::appdx-pycoin.asciidoc[]
 
 include::appdx-bx.asciidoc[]
 
-include::index.asciidoc[]
+include::ix.html[]
 
-include::colo.asciidoc[]
+include::colo.html[]


### PR DESCRIPTION
This fixes errors related to missing includes:
```
asciidoc: WARNING: book.asciidoc: line 5: include file not found: praise.asciidoc
asciidoc: WARNING: book.asciidoc: line 21: include file not found: ch06.asciidoc
asciidoc: WARNING: book.asciidoc: line 23: include file not found: ch07.asciidoc
asciidoc: WARNING: book.asciidoc: line 25: include file not found: ch08.asciidoc
asciidoc: WARNING: book.asciidoc: line 27: include file not found: ch09.asciidoc
asciidoc: WARNING: book.asciidoc: line 29: include file not found: ch10.asciidoc
asciidoc: WARNING: book.asciidoc: line 41: include file not found: index.asciidoc
asciidoc: WARNING: book.asciidoc: line 43: include file not found: colo.asciidoc
```