### PR TITLE
Update default value of datacarriersize.

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -212,7 +212,7 @@ Keep in mind that there is no "unlocking script" that corresponds to +RETURN+ th
 
 A standard transaction (one that conforms to the +isStandard()+ checks) can have only one +RETURN+ output. However, a single +RETURN+ output can be combined in a transaction with outputs of any other type.
 
-Two new command-line options have been added in Bitcoin Core as of version 0.10. The option +datacarrier+ controls relay and mining of RETURN transactions, with the default set to "1" to allow them. The option +datacarriersize+ takes a numeric argument specifying the maximum size in bytes of the RETURN data, 40 bytes by default.
+Two new command-line options have been added in Bitcoin Core as of version 0.10. The option +datacarrier+ controls relay and mining of RETURN transactions, with the default set to "1" to allow them. The option +datacarriersize+ takes a numeric argument specifying the maximum size in bytes of the RETURN script, 83 bytes by default which allows for a maximum of 80 bytes of RETURN data plus one byte of +RETURN+ opcode and two bytes of +PUSHDATA+ opcode.
 
 [NOTE]
 ====


### PR DESCRIPTION
The default value of datacarriersize has been updated to 83 to include
80 bytes of data and one byte of RETURN opcode and two bytes of PUSHDATA
opcode.