### PR TITLE
Fix BTC to satoshi calc

### DIFF
--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -156,7 +156,7 @@ See if you can manually decode Alice's transaction from the serialized hexadecim
 Here are some hints:
 
 * There are two outputs in the highlighted section, each serialized as shown in the table <<tx_out_structure>>
-* The value of 0.15 bitcoin is 1,500,000 satoshis. That's +16 e3 60+ in hexadecimal.
+* The value of 0.15 bitcoin is 15,000,000 satoshis. That's +16 e3 60+ in hexadecimal.
 * In the serialized transaction, the value +16 e3 60+ is encoded in little-endian (least-significant-byte-first) byte order, so it looks like +60 e3 16+
 * The +scriptPubKey+ length is 25 bytes, which is +19+ in hexadecimal
 


### PR DESCRIPTION
1,000,000 satoshi = 0.01 BTC so the example should be 0.15 BTC = 15,000,000 satoshi