### PR TITLE
Fix BTC to Satoshi calc second try

### DIFF
--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -156,7 +156,7 @@ See if you can manually decode Alice's transaction from the serialized hexadecim
 Here are some hints:
 
 * There are two outputs in the highlighted section, each serialized as shown in the table <<tx_out_structure>>
-* The value of 0.15 bitcoin is 15,000,000 satoshis. That's +16 e3 60+ in hexadecimal.
+* The value of 0.015 bitcoin is 1,5000,000 satoshis. That's +16 e3 60+ in hexadecimal.
 * In the serialized transaction, the value +16 e3 60+ is encoded in little-endian (least-significant-byte-first) byte order, so it looks like +60 e3 16+
 * The +scriptPubKey+ length is 25 bytes, which is +19+ in hexadecimal
 

--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -156,7 +156,7 @@ See if you can manually decode Alice's transaction from the serialized hexadecim
 Here are some hints:
 
 * There are two outputs in the highlighted section, each serialized as shown in the table <<tx_out_structure>>
-* The value of 0.015 bitcoin is 1,5000,000 satoshis. That's +16 e3 60+ in hexadecimal.
+* The value of 0.015 bitcoin is 1,500,000 satoshis. That's +16 e3 60+ in hexadecimal.
 * In the serialized transaction, the value +16 e3 60+ is encoded in little-endian (least-significant-byte-first) byte order, so it looks like +60 e3 16+
 * The +scriptPubKey+ length is 25 bytes, which is +19+ in hexadecimal
 


### PR DESCRIPTION
In my initial read I fixed the wrong part of the calc sorry about that, it should be 0.015 instead of 0.15 to be inline with the rest of the example so the change is - 0.015 bitcoin is 1,500,000 satoshis