### PR TITLE
Fixed verb tense agreement

### DIFF
--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -493,7 +493,7 @@ So far, we have not delved into any detail about "digital signatures". In this s
 
 The digital signature algorithm used in bitcoin is the _Elliptic Curve Digital Signature Algorithm_, or _ECDSA_. ECDSA is the algorithm used for digital signatures based on elliptic curve private/public key pairs, as described in <<ecc>>. ECDSA is used by the script functions OP_CHECKSIG, OP_CHECKSIGVERIFY, OP_CHECKMULTISIG and OP_CHECKMULTISIGVERIFY. Any time you see those in a locking script, the unlocking script must contain an ECDSA signature.
 
-A digital signature serves three purposes in bitcoin (see <<digital_signature_definition>>). First, the signature proves that the owner of the private key, who is by implication the owner of the funds, has *authorized* the spending of those funds. Secondly, the proof of authorization is *undeniable* (non-repudiation). Thirdly, the signature proves that the transaction (or specific parts of the transaction) have not and *can not be modified* by anyone after it has been been signed.
+A digital signature serves three purposes in bitcoin (see <<digital_signature_definition>>). First, the signature proves that the owner of the private key, who is by implication the owner of the funds, has *authorized* the spending of those funds. Secondly, the proof of authorization is *undeniable* (non-repudiation). Thirdly, the signature proves that the transaction has not and *can not be modified* by anyone after it has been been signed.
 
 Note that each transaction input is signed independently. This is critical, as neither the signatures, nor the inputs have to belong to or be applied by the same "owners". In fact, a specific transaction scheme called "CoinJoin" uses this fact to create multi-party transactions for privacy.
 


### PR DESCRIPTION
The verb "have" refers to a plural noun: (parts of a transaction) while other verbs in the sentence (ie, has) refer to the singular noun transaction. To resolve this confusion I have removed the (parts of a transaction) section. This allows subject and verb to be in agreement while preserving the meaning of the sentence.