### PR TITLE
nSequence must be greater than or equal to the CSV parameter

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -356,7 +356,7 @@ BIP-68 Relative lock-time using consensus-enforced sequence numbers:: https://gi
 
 Just like CLTV and nLocktime, there is a script opcode for relative timelocks that leverages the nSequence value in scripts. That opcode is +CHECKSEQUENCEVERIFY+ commonly referred to as +CSV_ for short.
 
-The CSV opcode when evaluated in a UTXO's redeem script, allows spending only in a transaction whose input nSequence value is lower than the CSV parameter. Essentially, this restricts spending the UTXO until a certain number of blocks or seconds have elapsed relative to the time the UTXO was mined.
+The CSV opcode when evaluated in a UTXO's redeem script, allows spending only in a transaction whose input nSequence value is greater than or equal to the CSV parameter. Essentially, this restricts spending the UTXO until a certain number of blocks or seconds have elapsed relative to the time the UTXO was mined.
 
 As with CLTV, the value in CSV must match the format in the corresponding nSequence value. If CSV is specified in terms of blocks, then so must nSequence. If CSV is specified in terms of seconds, then so must nSequence.
 


### PR DESCRIPTION
According to BIP 112, the script interpreter will terminate with an error if "the top stack item is greater than the transaction sequence." So the script can only succeed (allowing the spend) if the transaction input's nSequence is greater than or equal to the stack item (CSV parameter). In other words, the required number of blocks or seconds have elapsed.

The bitcoin source code seems to confirm this:
https://github.com/bitcoin/bitcoin/blob/1c2edd9f6707d16c03ecfba094b1cfec2ddc4dce/src/script/interpreter.cpp#L1350-L1351