### PR TITLE
Correct labeled count of questions

### DIFF
--- a/ch01.asciidoc
+++ b/ch01.asciidoc
@@ -29,7 +29,7 @@ In this chapter we'll get started by explaining some of the main concepts and te
 .Digital Currencies Before Bitcoin
 ****
 
-((("bitcoin","precursors to")))The emergence of viable digital money is closely linked to developments in cryptography. This is not surprising when one considers the fundamental challenges involved with using bits to represent value that can be exchanged for goods and services. Two basic questions for anyone accepting digital money are:
+((("bitcoin","precursors to")))The emergence of viable digital money is closely linked to developments in cryptography. This is not surprising when one considers the fundamental challenges involved with using bits to represent value that can be exchanged for goods and services. Three basic questions for anyone accepting digital money are:
 
 1.     Can I trust the money is authentic and not counterfeit?
 2.     Can I trust that the digital money can only be spent once (known as the((("double-spend problem"))) “double-spend” problem.)


### PR DESCRIPTION
There are three questions listed, not two. This change updates the labeled count from "Two" to "Three".