### PR TITLE
Typo in ch12.asciidoc

### DIFF
--- a/ch12.asciidoc
+++ b/ch12.asciidoc
@@ -103,7 +103,7 @@ Finally, some colored coins enable _dividends_, allowing the distribution of bit
 
 ==== Colored Coins Transactions
 
-The metadata that gives meaning to a colored coin transaction is usually stored in one of the outputs using the OP_RETURN opcode. Different colored coins protocols use different encodings for the content of the OP_RETURN data. The output containing the OP_RETURN is called the _marker output_
+The metadata that gives meaning to a colored coin transaction is usually stored in one of the outputs using the OP_RETURN opcode. Different colored coins protocols use different encodings for the content of the OP_RETURN data. The output containing the OP_RETURN is called the _marker output_.
 
 The order of the outputs and position of the marker output may have special meaning in the colored coins protocol. In Open Assets, for example, any outputs before the marker output represent asset issuance. Any outputs after the marker represent asset transfer. The marker output assigns specific values and colors to the other outputs by referencing their order in the transaction.
 


### PR DESCRIPTION
Fixes #252. Added full stop at the end of "The output containing the OP_RETURN is called the marker output"