### PR TITLE
Typos in glossary.asciidoc

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -56,7 +56,7 @@ difficulty target::
     A difficulty at which all the computation in the network will find blocks approximately every 10 minutes.((("target difficulty")))
 
 Double spending::
-    Double-spending is the result of successfully spending some money more than once. Bitcoin protects against double spending by verifying each transaction added to the block chain to ensure that the inputs for the transaction had not previously already been spent. ((("Double spendingy")))
+    Double-spending is the result of successfully spending some money more than once. Bitcoin protects against double spending by verifying each transaction added to the block chain to ensure that the inputs for the transaction had not previously already been spent. ((("Double spending")))
 
 ECDSA::
     Elliptic Curve Digital Signature Algorithm or ECDSA is a cryptographic algorithm used by Bitcoin to ensure that funds can only be spent by their rightful owners.((("ECDSA")))((("Elliptic Curve Digital Signature Algorithm", see="Elliptic Curve Digital Signature Algorithm")))
@@ -74,7 +74,7 @@ genesis block::
 	The first block in the blockchain, used to initialize the cryptocurrency.((("genesis block")))
 
 Hard Fork::
-    Hard Fork, also known as Hard-Forking Change, is a permanent divergence in the the block chain, commonly occurs when non-upgraded nodes can’t validate blocks created by upgraded nodes that follow newer consensus rules.
+    Hard Fork, also known as Hard-Forking Change, is a permanent divergence in the blockchain, commonly occurs when non-upgraded nodes can’t validate blocks created by upgraded nodes that follow newer consensus rules.
     Not to be confused with Fork, Soft fork, Software fork or Git fork. ((("Hard Fork")))((("Hard-Forking Change", see="Hard Fork")))
 
 Hardware Wallet::
@@ -174,7 +174,7 @@ Paper wallet::
     In the most specific sense, a paper wallet is a document containing all of the data necessary to generate any number of Bitcoin private keys, forming a wallet of keys. However, people often use the term to mean any way of storing bitcoins offline as a physical document. This second definition also includes paper keys and redeemable codes. ((("Paper wallet")))
 
 Payment channels::
-    A Micropayment Channel or Payment Channel is class of techniques designed to allow users to make multiple Bitcoin transactions without commiting all of the transactions to the Bitcoin block chain. In a typical payment channel, only two transactions are added to the block chain but an unlimited or nearly unlimted number of payments can be made between the participants. ((("Payment channels")))
+    A Micropayment Channel or Payment Channel is class of techniques designed to allow users to make multiple Bitcoin transactions without committing all of the transactions to the Bitcoin block chain. In a typical payment channel, only two transactions are added to the block chain but an unlimited or nearly unlimited number of payments can be made between the participants. ((("Payment channels")))
 
 Pooled mining::
     Pooled mining is a mining approach where multiple generating clients contribute to the generation of a block, and then split the block reward according the contributed processing power. ((("Pooled mining")))


### PR DESCRIPTION
"the the block chain" -> "the blockchain"
spendingy -> spending
commiting -> committing
unlimted -> unlimited