### PR TITLE
Lightning Network announced in 2015

### DIFF
--- a/ch12.asciidoc
+++ b/ch12.asciidoc
@@ -414,7 +414,7 @@ This is a basic implementation of an HTLC. This type of HTLC can be redeemed by 
 
 === Routed Payment Channels (Lightning Network)
 
-The Lightning Network is a proposed routed network of bi-directional payment channels connected end-to-end. A network like this can allow any participant to route a payment from channel to channel without trusting any of the intermediaries. The Lightning Network was first described by Joseph Poon and Thadeus Dryja in January 2016, building on the concept of payment channels as proposed and elaborate by many others:
+The Lightning Network is a proposed routed network of bi-directional payment channels connected end-to-end. A network like this can allow any participant to route a payment from channel to channel without trusting any of the intermediaries. The Lightning Network was first described by Joseph Poon and Thadeus Dryja in February 2015, building on the concept of payment channels as proposed and elaborate by many others:
 
 http://lightning.network/lightning-network-paper.pdf[lightning.network/lightning-network-paper.pdf]
 


### PR DESCRIPTION
The first draft of the Lightning Network whitepaper was released in February 2015, not January 2016.

Source: https://blockstream.com/2015/09/01/lightning-network.html