### PR TITLE
Typo in glossary.asciidoc

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -216,7 +216,7 @@ Soft Fork::
     Soft Fork or Soft-Forking Change is a temporary fork in the Blockchain which commonly occurs when miners using non-upgraded nodes don't follow a new consensus rule their nodes don’t know about.
     Not to be confused with Fork, Hard fork, Software fork or Git fork. ((("Soft Fork")))((("Soft-Forking Change", see="Soft Fork")))
 
-SPV (akka Simplified Payment Verification)::
+SPV (aka Simplified Payment Verification)::
     SPV or Simplified Payment Verification is a method for verifying particular transactions were included in a block without downloading the entire block. The method is used by some lightweight Bitcoin clients. ((("SPV")))((("Simplified Payment Verification", see="SPV")))
 
 Stale Block::
@@ -234,11 +234,11 @@ Transaction Pool::
 Turing completeness::
      A program language is called "Turing complete", if that it can run any program that a Turing machine can run given enough time and memory. ((("Turing completeness")))
 
-UTXO (akka Unspent Transaction Output)::
+UTXO (aka Unspent Transaction Output)::
     UTXO is an Unspent Transaction Output that can be spent as an input in a new transaction. ((("UTXO")))
 
 wallet::
     Software that holds all your bitcoin addresses and secret keys. Use it to send, receive, and store your bitcoin.((("wallet"))) 
 
-WIF (akka Wallet Import Format)::
+WIF (aka Wallet Import Format)::
     WIF or Wallet Import Format is a data interchange format designed to allow exporting and importing a single private key with a flag indicating whether or not it uses a compressed public key. ((("WIF")))


### PR DESCRIPTION
3 instances of "akka" turned into "aka" (also known as).