### PR TITLE
bitcoinj moved from Google Code -> Github

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -760,7 +760,7 @@ https://bitcore.io/[Bitcore] :: Full node, API and library by Bitpay
 https://github.com/bitcoinjs/bitcoinjs-lib[BitcoinJS] :: A pure JavaScript Bitcoin library for node.js and browsers
 
 ==== Java
-https://code.google.com/p/bitcoinj/[bitcoinj]:: ((("BitcoinJ library")))A Java full-node client library
+https://bitcoinj.github.io[bitcoinj]:: ((("BitcoinJ library")))A Java full-node client library
 https://bitsofproof.com[Bits of Proof (BOP)]:: ((("Bits of Proof (BOP)")))A Java enterprise-class implementation of bitcoin
 
 ==== Python


### PR DESCRIPTION
https://code.google.com/p/bitcoinj/ now redirects to https://bitcoinj.github.io, hence the URL change in ch03.asciidoc