### PR TITLE
Fix alphabetical order of wallets.

### DIFF
--- a/ch05.asciidoc
+++ b/ch05.asciidoc
@@ -95,7 +95,7 @@ These standards may change or may become obsolete by future developments, but fo
 
 The standards have been adopted by a broad range of software and hardware bitcoin wallets, making all these wallets interoperable. A user can export a mnemonic generated on one of these wallets and import it in another wallet, recovering all transactions, keys and addresses. 
 
-Some example of software wallets supporting these standards include (listed alphabetically) Copay, Breadwallet, Multibit HD and Mycelium. Examples of hardware wallets supporting these standards include (listed alphabetically) Keepkey, Ledger and Trezor. 
+Some example of software wallets supporting these standards include (listed alphabetically) Breadwallet, Copay, Multibit HD and Mycelium. Examples of hardware wallets supporting these standards include (listed alphabetically) Keepkey, Ledger and Trezor. 
 
 The following sections examine each of these technologies in detail. 
 


### PR DESCRIPTION
Copay was before Breadwallet.