### PR TITLE
Update ch04.asciidoc, no RPC client functionality in bitcoind

### DIFF
--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -82,9 +82,9 @@ The size of bitcoin's private key space, 2^256^ is an unfathomably large number.
 To generate a new key with the Bitcoin Core client (see <<ch03_bitcoin_client>>), use the((("getnewaddress command (bitcoin-cli)"))) +getnewaddress+ command. For security reasons it displays the public key only, not the private key. ((("dumpprivkey command (bitcoin-cli)")))((("private keys","exposing with bitcoind")))To ask bitcoind to expose the private key, use the +dumpprivkey+ command. The +dumpprivkey+ command shows the private key in a Base58 checksum-encoded format called the _Wallet Import Format_ (WIF), which we will examine in more detail in <<priv_formats>>. Here's an example of generating and displaying a private key using these two commands:
 
 ----
-$ bitcoind getnewaddress
+$ bitcoin-cli getnewaddress
 1J7mdg5rbQyUHENYdx39WVWK7fsLpEoXZy
-$ bitcoind dumpprivkey 1J7mdg5rbQyUHENYdx39WVWK7fsLpEoXZy
+$ bitcoin-cli dumpprivkey 1J7mdg5rbQyUHENYdx39WVWK7fsLpEoXZy
 KxFC1jmwwCoACiCAWZ3eXa96mBM6tb3TYzGmf6YwgdGWZgawvrtJ
 ----
 


### PR DESCRIPTION
no RPC client functionality in bitcoind anymore. Use the bitcoin-cli utility instead.