### PR TITLE
Made sentence clearer

### DIFF
--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -1,7 +1,7 @@
 [[ch04_keys_addresses]]
 == Keys, Addresses
 
-You may have heard that bitcoin is based on _cryptography_, which is a branch of mathematics used extensively in computer security. Cryptography means secret writing but than just encryption. Cryptography can also be used to prove knowledge of a secret without revealing that secret (digital signatures), or prove the authenticity of data (digital fingerprints). These types of cryptographic proofs are the mathematical tools critical to bitcoin and used extensively in bitcoin applications. Ironically, encryption is not an important part of bitcoin, as its communications and transaction data are not encrypted and do not need to be encrypted to protect the funds. In this chapter we will introduce some of the cryptography used in bitcoin to control ownership of funds, in the form of keys, addresses and wallets. 
+You may have heard that bitcoin is based on _cryptography_, which is a branch of mathematics used extensively in computer security. Cryptography means secret writing more than just encryption. Cryptography can also be used to prove knowledge of a secret without revealing that secret (digital signatures), or prove the authenticity of data (digital fingerprints). These types of cryptographic proofs are the mathematical tools critical to bitcoin and used extensively in bitcoin applications. Ironically, encryption is not an important part of bitcoin, as its communications and transaction data are not encrypted and do not need to be encrypted to protect the funds. In this chapter we will introduce some of the cryptography used in bitcoin to control ownership of funds, in the form of keys, addresses and wallets. 
 
 === Introduction
 


### PR DESCRIPTION
Changed `but` to `more` in the sentence `Cryptography means secret writing but than just encryption.`
Not sure if this was the author's intent.
How about using the following sentence instead and removing the reference to encryption since it's referred to a bit later?
`...extensively in computer security. We usually talk about cryptography in the context of secret communications. Cryptography can also be used...`