### PR TITLE
Markup typo in ch09.asciidoc

### DIFF
--- a/ch09.asciidoc
+++ b/ch09.asciidoc
@@ -258,7 +258,7 @@ Consider, for example, an SPV node that is interested in incoming payments to an
 === Bitcoin's Test Blockchains
 
 You might be surprised to learn that there is more than one bitcoin blockchain. The "main" bitcoin blockchain, the one created by Satoshi Nakamoto on January 3rd 2009, the one with the genesis block we studied in this chapter, is called _mainnet_. ((("mainnet")))((("blockchain", "mainnet"))) There are other bitcoin blockchains that are used for testing purposes: at this time _testnet_, _segnet_ and _regtest_. Let's look at each in turn.((("testnet")))((("blockchain","testnet")))((("segnet")))
-((("blockchain","segnet")))((("regtest")))(("blockchain","regtest")))
+((("blockchain","segnet")))((("regtest")))((("blockchain","regtest")))
 
 ==== Testnet - Bitcoin's testing playground
 


### PR DESCRIPTION
Typo in markup defining index keywords.