### PR TITLE
Markup typo in ch07.asciidoc

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -352,7 +352,7 @@ BIP-68 Relative lock-time using consensus-enforced sequence numbers:: https://gi
 
 ==== Relative timelocks with CHECKSEQUENCEVERIFY (CSV)
 
-Just like CLTV and nLocktime, there is a script opcode for relative timelocks that leverages the nSequence value in scripts. That opcode is +CHECKSEQUENCEVERIFY+ commonly referred to as +CSV_ for short.
+Just like CLTV and nLocktime, there is a script opcode for relative timelocks that leverages the nSequence value in scripts. That opcode is +CHECKSEQUENCEVERIFY+ commonly referred to as _CSV_ for short.
 
 The CSV opcode when evaluated in a UTXO's redeem script, allows spending only in a transaction whose input nSequence value is greater than or equal to the CSV parameter. Essentially, this restricts spending the UTXO until a certain number of blocks or seconds have elapsed relative to the time the UTXO was mined.
 


### PR DESCRIPTION
I think the +CSV_ markup is a typo. Given this sentence introduces this term, I assume the author wanted to format in italics i.e. _CSV_