### PR TITLE
Update Example 4-3 to work with current libbitcoin API.

### DIFF
--- a/code/addr.cpp
+++ b/code/addr.cpp
@@ -7,10 +7,13 @@ int main()
     bool success = bc::decode_base16(secret,
         "038109007313a5807b2eccc082c8c3fbb988a973cacf1a7df9ce725c31b14776");
     assert(success);
+   
     // Get public key.
-    bc::ec_point public_key = bc::secret_to_public_key(secret);
-    std::cout << "Public key: " << bc::encode_hex(public_key) << std::endl;
-
+    bc::ec_compressed public_key;
+    success = bc::secret_to_public(public_key, secret);
+    assert(success);
+    std::cout << "Public key: " << bc::encode_base16(public_key) << std::endl;
+    
     // Create Bitcoin address.
     // Normally you can use:
     //   bc::payment_address payaddr;


### PR DESCRIPTION
In order to try Example 4-3 in the 2nd edition, I had to make a few changes in order to compile against the current libbitcoin master ([f5c93908](https://github.com/libbitcoin/libbitcoin/commit/f5c93908348c15d81cced8e85fbb0e4378f27b91)).

On my Mac (macOS Sierra 10.12.5), it was also necessary to tell g++ to use the C++11 standard:

```
$ which g++
/usr/bin/g++
$ g++ --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 8.1.0 (clang-802.0.42)
Target: x86_64-apple-darwin16.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
$ g++ -std=c++11 -o addr addr.cpp $(pkg-config --cflags --libs libbitcoin)
$ ./addr
Public key: 0202a406624211f2abbdc68da3df929f938c3399dd79fac1b51b0e4ad1d26a47aa
Address: 1PRTTaJesdNovgne6Ehcdu1fpEdX7913CK

```