### PR TITLE
fixed bip32 child key derivation error

### DIFF
--- a/ch05.asciidoc
+++ b/ch05.asciidoc
@@ -318,7 +318,7 @@ The chain code is used to introduce deterministic random data to the process, so
 
 These three items (parent key, chain code and index) are combined and hashed to generate children keys, as follows.
 
-The parent public key, chain code, and the index number are combined and hashed with the HMAC-SHA512 algorithm to produce a 512-bit hash. This 512-bit hash is split into two 256-bit halves. The right-half 256 bits of the hash output become the chain code for the child. The left-half 256 bits of the hash and the index number are added to the parent private key to produce the child private key. In <<CKDpriv>>, we see this illustrated with the index set to 0 to produce the "zero" (first by index) child of the parent.
+The parent public key, chain code, and the index number are combined and hashed with the HMAC-SHA512 algorithm to produce a 512-bit hash. This 512-bit hash is split into two 256-bit halves. The right-half 256 bits of the hash output become the chain code for the child. The left-half 256 bits of the hash are added to the parent private key to produce the child private key. In <<CKDpriv>>, we see this illustrated with the index set to 0 to produce the "zero" (first by index) child of the parent.
 
 [[CKDpriv]]
 .Extending a parent private key to create a child private key


### PR DESCRIPTION
only hash is added to parent key, not hash **and** index