### PR TITLE
Add free automated flake8 testing on all pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+python:
+    - 2.7.13
+    - 3.6.2
+branches:
+  only:
+    - develop
+install:
+    - pip install flake8  # pytest  # add other testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # add other tests here
+notifications:
+    on_success: change
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-    - 2.7.13
-    - 3.6.2
+    - 2.7
+    - 3.6
 branches:
   only:
     - develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
 branches:
   only:
     - develop
+    - first_edition
+    - second_edition
 install:
     - pip install flake8  # pytest  # add other testing frameworks later
 before_script:


### PR DESCRIPTION
The Travis Continuous Integration service is free for all open source projects like this one. This configuration will enable Travis CI to run [flake8](http://flake8.pycqa.org) tests on all pull requests before they are reviewed. This allows contributors and maintainers to make sure no errors are introduced.  The owner of this repo would need to go to https://travis-ci.org/profile (log in via GitHub id) and flip the repository switch __on__ to enable free, automated flake8 testing of each pull request.

Output should look something like this: https://travis-ci.org/cclauss/flake8-for-bitcoinbook