### PR TITLE
make binary and hex values consistent

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -321,9 +321,9 @@ BIP-68 and BIP-112 were activated in May 2016 as a soft fork upgrade to the cons
 
 ===== Original meaning of nSequence
 
-The +nSequence+ field was originally intended (but never properly implemented) to allow modification of transactions in the mempool. In that use, a transaction containing inputs with +nSequence+ value below 2^32^ (0xFFFFFFFF) indicated a transaction that was not yet "finalized." Such a transaction would be held in the mempool until it was replaced by another transaction spending the same inputs with a higher +nSequence+ value. Once a transaction was received whose inputs had an +nSequence+ value of 2^32^ it would be considered "finalized" and mined.
+The +nSequence+ field was originally intended (but never properly implemented) to allow modification of transactions in the mempool. In that use, a transaction containing inputs with +nSequence+ value below 2^32^ - 1 (0xFFFFFFFF) indicated a transaction that was not yet "finalized." Such a transaction would be held in the mempool until it was replaced by another transaction spending the same inputs with a higher +nSequence+ value. Once a transaction was received whose inputs had an +nSequence+ value of 0xFFFFFFFF it would be considered "finalized" and mined.
 
-The original meaning of +nSequence+ was never properly implemented and the value of +nSequence+ is customarily set to 2^32^ in transactions that do not utilize timelocks. For transactions with nLocktime or +CHECKLOCKTIMEVERIFY+, the +nSequence+ value must be set to less than 2^32^ for the timelock guards to have effect. Customarily, it is set to pass:[<span class="keep-together">2<sup>32</sup> &#x2013; 1</span>] (0xFFFFFFFE).
+The original meaning of +nSequence+ was never properly implemented and the value of +nSequence+ is customarily set to 0xFFFFFFFF in transactions that do not utilize timelocks. For transactions with nLocktime or +CHECKLOCKTIMEVERIFY+, the +nSequence+ value must be set to less than 2^31^ for the timelock guards to have effect, as explained below.
 
 ===== nSequence as a consensus-enforced relative timelock
 


### PR DESCRIPTION
Fixes inconsistencies in binary/hex numbers as raised in https://github.com/bitcoinbook/bitcoinbook/issues/354

Also, sets the values to the correct numbers based on  https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki and observed typical values for nSequence