### PR TITLE
Fix mixing up sequence number with the index

### DIFF
--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -171,7 +171,7 @@ Here are some hints:
 
 To build a transaction, a wallet selects from the UTXO it controls, UTXO with enough value to make the requested payment. Sometimes one UTXO is enough, other times more than one is needed. For each UTXO that will be consumed to make this payment, the wallet creates one input pointing to the UTXO and unlocks it with an unlocking script.
 
-Let's look at the components of an input in greater detail. The first part of an input is a pointer to an UTXO by reference to the transaction hash and sequence number where the UTXO is recorded in the blockchain. The second part is an unlocking script, which the wallet constructs in order to satisfy the spending conditions set in the UTXO. Most often, the unlocking script is a digital signature and public key proving ownership of the bitcoin. However, not all unlocking scripts contain signatures. The third part is a sequence number, which will be discussed later.
+Let's look at the components of an input in greater detail. The first part of an input is a pointer to an UTXO: `txid`, `vout`. `txid` is a transaction hash, it references the transaction, which contains the UTXO. `vout` is an index number, it references the UTXO within the referenced transaction. The second part is an unlocking script: `scriptSig`, which the wallet constructs in order to satisfy the spending conditions set in the UTXO. Most often, the unlocking script is a digital signature and public key proving ownership of the bitcoin. However, not all unlocking scripts contain signatures. The third part is a sequence number: `sequence`, which will be discussed later.
 
 Consider our example in <<transactions_behind_the_scenes>>. The transaction inputs are an array (list) called +vin+:
 


### PR DESCRIPTION
The description was describing the index as it would've been the sequence number.