### PR TITLE
Clearer description of the decendants in HD wallet key path table

### DIFF
--- a/ch05.asciidoc
+++ b/ch05.asciidoc
@@ -65,7 +65,7 @@ image::images/mbc2_0503.png["HD wallet"]
 
 HD wallets offer two major advantages over random (nondeterministic) keys. First, the tree structure can be used to express additional organizational meaning, such as when a specific branch of subkeys is used to receive incoming payments and a different branch is used to receive change from outgoing payments. Branches of keys can also be used in corporate settings, allocating different branches to departments, subsidiaries, specific functions, or accounting categories.
 
-The second advantage of HD wallets is that users can create a sequence of public keys without having access to the corresponding private keys. This allows HD wallets to be used on an insecure server or in a receive-only capacity, issuing a different public key for each transaction. The public keys need to be preloaded or derived in advance, yet the server doesn't have the private keys that can spend the funds. 
+The second advantage of HD wallets is that users can create a sequence of public keys without having access to the corresponding private keys. This allows HD wallets to be used on an insecure server or in a receive-only capacity, issuing a different public key for each transaction. The public keys need to be preloaded or derived in advance, yet the server doesn't have the private keys that can spend the funds.
 
 ==== Seeds and Mnemonic Codes (BIP-39)
 
@@ -452,10 +452,10 @@ The "ancestry" of a key is read from right to left, until you reach the master k
 |=======
 |HD path | Key described
 | m/0 | The first (0) child private key from the master private key (m)
-| m/0/0 | The first grandchild private key of the first child (m/0)
-| m/0'/0 | The first normal grandchild of the first _hardened_ child (m/0')
-| m/1/0 | The first grandchild private key of the second child (m/1)
-| M/23/17/0/0 | The first great-great-grandchild public key of the first great-grandchild of the 18th grandchild of the 24th child
+| m/0/0 | The first grandchild private key from the first child (m/0)
+| m/0'/0 | The first normal grandchild from the first _hardened_ child (m/0')
+| m/1/0 | The first grandchild private key from the second child (m/1)
+| M/23/17/0/0 | The first great-great-grandchild public key from the first great-grandchild from the 18th grandchild from the 24th child
 |=======
 
 ===== Navigating the HD wallet tree structure


### PR DESCRIPTION
Hi,

The descriptions for each of the descendants keys in the [HD wallet key paths identifier (path) table in chapter 5 ](descendants) are a bit confusing in the way the sentences are structured. I have simply replaced the word 'of' with 'from' in some places, which I think removes the confusion of which key is a direct child of which parent key.