### PR TITLE
Fix syntax issue in displaying HTML entity (curly braces) in ch.06

### DIFF
--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -438,7 +438,7 @@ As we saw in the step-by-step example in <<simplemath_script>>, when this script
 
 [TIP]
 ====
-((("transactions", "valid and invalid")))Transactions are valid if the top result on the stack is +TRUE+ (noted as ++&#x7b;0x01&#x7d;++), any other nonzero value, or if the stack is empty after script execution. Transactions are invalid if the top value on the stack is +FALSE+ (a zero-length empty value, noted as ++&#x7b;&#x7d;++) or if script execution is halted explicitly by an operator, such as +OP_VERIFY+, +OP_RETURN+, or a conditional terminator such as +OP_ENDIF+. See <<tx_script_ops>> for details.
+((("transactions", "valid and invalid")))Transactions are valid if the top result on the stack is +TRUE+ (noted as +++&#x7b;0x01&#x7d;+++), any other nonzero value, or if the stack is empty after script execution. Transactions are invalid if the top value on the stack is +FALSE+ (a zero-length empty value, noted as +++&#x7b;&#x7d;+++) or if script execution is halted explicitly by an operator, such as +OP_VERIFY+, +OP_RETURN+, or a conditional terminator such as +OP_ENDIF+. See <<tx_script_ops>> for details.
 ====
 
 [[simplemath_script]]


### PR DESCRIPTION
This addresses #433, where the HTML codes for curly braces are not being properly escaped.