### PR TITLE
Add detail to a benefit of P2SH

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -172,7 +172,7 @@ P2SH addresses hide all of the complexity, so that the person making a payment d
 * Complex scripts are replaced by shorter fingerprints in the transaction output, making the transaction smaller.
 * Scripts can be coded as an address, so the sender and the sender's wallet don't need complex engineering to implement P2SH.
 * P2SH shifts the burden of constructing the script to the recipient, not the sender.
-* P2SH shifts the burden in data storage for the long script from the output (which is in the UTXO set) to the input (stored on the blockchain).
+* P2SH shifts the burden in data storage for the long script from the output (which additionally to being stored on the blockchain is in the UTXO set) to the input (only stored on the blockchain).
 * P2SH shifts the burden in data storage for the long script from the present time (payment) to a future time (when it is spent).
 * P2SH shifts the transaction fee cost of a long script from the sender to the recipient, who has to include the long redeem script to spend it.
 


### PR DESCRIPTION
The bullet point previously sounded as if the long script was only stored in the UTXO set when not using P2SH, and stored on the blockchain when using P2SH. This might lead to people thinking it might lead to a smaller blockchain when the script is stored in the UTXO set *instead* of on the blockchain. But without P2SH the long script was stored both in the UTXO set *and* on the blockchain. With P2SH it's only stored on the blockchain, which is a clear advantage over not using P2SH.