### PR TITLE
Fix a Python 2 syntax error

### DIFF
--- a/code/pycoin_example.py
+++ b/code/pycoin_example.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 from pycoin.key import Key
 
 from pycoin.key.validate import is_address_valid, is_wif_valid


### PR DESCRIPTION
flake8 testing of https://github.com/bitcoinbook/bitcoinbook on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./code/pycoin_example.py:11:53: E999 SyntaxError: invalid syntax
        print("enter the %s address=> " % which, end='')
                                                    ^
1     E999 SyntaxError: invalid syntax
```