### PR TITLE
Mistake in HTLC contract definition.

### DIFF
--- a/ch12.asciidoc
+++ b/ch12.asciidoc
@@ -426,13 +426,13 @@ IF
 ELSE
     # Refund after timeout.
     <locktime> CHECKLOCKTIMEVERIFY DROP
-    <Payee Pubic Key> CHECKSIG
+    <Payer Pubic Key> CHECKSIG
 ENDIF
 ----
 
 Anyone who knows the secret +R+, which when hashed equals to +H+, can redeem this output by exercising the first clause of the +IF+ flow.
 
-If the secret is not revealed and the HTLC claimed, after a certain number of blocks the payee can claim a refund using the second clause in the +IF+ flow.
+If the secret is not revealed and the HTLC claimed, after a certain number of blocks the payer can claim a refund using the second clause in the +IF+ flow.
 
 This is a basic implementation of an HTLC. This type of HTLC can be redeemed by _anyone_ who has the secret +R+. An HTLC can take many different forms with slight variations to the script. For example, adding a +CHECKSIG+ operator and a public key in the first clause restricts redemption of the hash to a named recipient, who must also know the secret +R+.((("", startref="BCApayment12")))
 


### PR DESCRIPTION
According to the logic of the smart contract, if the recipient has not received secret R during the certain number of blocks, the sender (payer) can claim a refund, not the recipient (payee).