### PR TITLE
Update key-to-address-ecc-example.py

### DIFF
--- a/code/key-to-address-ecc-example.py
+++ b/code/key-to-address-ecc-example.py
@@ -35,7 +35,7 @@ print("Public Key (hex) is:", hex_encoded_public_key)
 # Compress public key, adjust prefix depending on whether y is even or odd
 (public_key_x, public_key_y) = public_key
 compressed_prefix = '02' if (public_key_y % 2) == 0 else '03'
-hex_compressed_public_key = compressed_prefix + bitcoin.encode(public_key_x, 16)
+hex_compressed_public_key = compressed_prefix + (bitcoin.encode(public_key_x, 16).zfill(64))
 print("Compressed Public Key (hex) is:", hex_compressed_public_key)
 
 # Generate bitcoin address from public key


### PR DESCRIPTION
The code is miss a leading '0'.
E.g:
Private Key (hex) is: 57c003d31cca32f79a22e70334fff37875617e89c04d2746b5efc22067ccb8fd
Before: Compressed Public Key (hex) is: 03 8f0de2360796ae0fe17f1a2b0be30af6fb45eccc4a1c7afb5ebea21d041b6e0
After: Compressed Public Key (hex) is: 03 08f0de2360796ae0fe17f1a2b0be30af6fb45eccc4a1c7afb5ebea21d041b6e0