### PR TITLE
Create .travis.yml for the first edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+python:
+    - 2.7
+    - 3.6
+branches:
+  only:
+    - develop
+    - first_edition
+    - second_edition
+install:
+    - pip install flake8  # pytest  # add other testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # add other tests here
+notifications:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
Like #352 but for the branch first_edition.  See https://github.com/bitcoinbook/bitcoinbook/pulls?q=is%3Apr+is%3Aclosed+author%3Acclauss for fixes to flake8 errors in branch first_edition.  Of special interest is the Syntax Error fixed in #473