### PR TITLE
script opcode count IF vs. VERIFY: diff is two ops

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -498,7 +498,7 @@ Bob's unlocking script is identical:
 <Bob's Sig> <hash pre-image>
 ----
 
-The script with +IF+ does the same thing as using an opcode with a +VERIFY+ suffix; they both operate as guard clauses. However, the +VERIFY+ construction is more efficient, using one fewer opcode.
+The script with +IF+ does the same thing as using an opcode with a +VERIFY+ suffix; they both operate as guard clauses. However, the +VERIFY+ construction is more efficient, using two fewer opcodes.
 
 So, when do we use +VERIFY+ and when do we use +IF+? If all we are trying to do is to attach a precondition (guard clause), then +VERIFY+ is better. If, however, we want to have more than one execution path (flow control), then we need an +IF...ELSE+ flow control clause.
 


### PR DESCRIPTION
v1: `HASH160 <expected hash> EQUALVERIFY <Bob's Pubkey> CHECKSIG`
v2: `HASH160 <expected hash> EQUAL IF <Bob's Pubkey> CHECKSIG ENDIF`

ignoring the push-data ops (hash, pubkey),
v1 consists of [HASH160, EQUALVERIFY, CHECKSIG] -> 3 opcodes,
v2 consists of [HASH160, EQUAL, IF, CHECKSIG, ENDIF] -> 5 opcodes,
hence the difference is two opcodes.