### PR TITLE
Fix wrong hashing rate numbers

### DIFF
--- a/ch10.asciidoc
+++ b/ch10.asciidoc
@@ -831,7 +831,7 @@ The following list shows the total hashing power of the bitcoin network, over th
 
 2009:: 0.5 MH/sec–8 MH/sec (16&#x00D7; growth)
 2010:: 8 MH/sec–116 GH/sec (14,500&#x00D7; growth)
-2011:: 16 GH/sec–9 TH/sec (562&#x00D7; growth)
+2011:: 116 GH/sec–9 TH/sec (78&#x00D7; growth)
 2012:: 9 TH/sec–23 TH/sec (2.5&#x00D7; growth)
 2013:: 23 TH/sec–10 PH/sec (450&#x00D7; growth)
 2014:: 10 PH/sec–300 PH/sec (3000&#x00D7; growth)


### PR DESCRIPTION
I think this was an unintentional error when copying the number from the previous line, so instead of copying 116 only the 16 was copied.

Now theoretically the hashing rate could have dropped between 2010-12-31 and 2011-01-01, but this wasn't the case, as can be checked on charts like https://bitinfocharts.com/comparison/bitcoin-hashrate.html