### PR TITLE
Unable to compile without providing c++ version flag

### DIFF
--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -521,7 +521,7 @@ The code uses a predefined private key to produce the same bitcoin address every
 [source,bash]
 ----
 # Compile the addr.cpp code
-$ g++ -o addr addr.cpp $(pkg-config --cflags --libs libbitcoin)
+$ g++ -o addr addr.cpp -std=c++11 $(pkg-config --cflags --libs libbitcoin)
 # Run the addr executable
 $ ./addr
 Public key: 0202a406624211f2abbdc68da3df929f938c3399dd79fac1b51b0e4ad1d26a47aa


### PR DESCRIPTION
I was unable to compile the example without providing the compile flag `-std=c++11`

https://github.com/libbitcoin/libbitcoin/issues/850