### PR TITLE
fixed annual hashing growth rates for y. 2014-2016

### DIFF
--- a/ch10.asciidoc
+++ b/ch10.asciidoc
@@ -834,9 +834,9 @@ The following list shows the total hashing power of the bitcoin network, over th
 2011:: 116 GH/sec–9 TH/sec (78&#x00D7; growth)
 2012:: 9 TH/sec–23 TH/sec (2.5&#x00D7; growth)
 2013:: 23 TH/sec–10 PH/sec (450&#x00D7; growth)
-2014:: 10 PH/sec–300 PH/sec (3000&#x00D7; growth)
-2015:: 300 PH/sec-800 PH/sec (266&#x00D7; growth)
-2016:: 800 PH/sec-2.5 EH/sec (312&#x00D7; growth))
+2014:: 10 PH/sec–300 PH/sec (30&#x00D7; growth)
+2015:: 300 PH/sec-800 PH/sec (2.66&#x00D7; growth)
+2016:: 800 PH/sec-2.5 EH/sec (3.12&#x00D7; growth))
 
 In the chart in <<network_hashing_power>>, we can see that bitcoin network's hashing power increased over the past two years. As you can see, the competition between miners and the growth of bitcoin has resulted in an exponential increase in the hashing power (total hashes per second across the network).
 


### PR DESCRIPTION
2014: 300 PH / 10 PH = 30
2015: 800 PH / 300 PH = 2.66
2016: 2500 PH / 800 PH = 3.12
(i.e. growth rates were off by a factor of 100)