### PR TITLE
fixed hashlib library error for python3

### DIFF
--- a/code/hash_example.py
+++ b/code/hash_example.py
@@ -12,7 +12,7 @@ for nonce in range(20):
     input_data = text + str(nonce)
 
     # calculate the SHA-256 hash of the input (text+nonce)
-    hash_data = hashlib.sha256(input_data).hexdigest()
+    hash_data = hashlib.sha256(input_data.encode()).hexdigest()
 
     # show the input and hash result
     print(input_data, '=>', hash_data)

--- a/code/proof-of-work-example.py
+++ b/code/proof-of-work-example.py
@@ -19,7 +19,7 @@ def proof_of_work(header, difficulty_bits):
     target = 2 ** (256 - difficulty_bits)
 
     for nonce in xrange(max_nonce):
-        hash_result = hashlib.sha256(str(header) + str(nonce)).hexdigest()
+        hash_result = hashlib.sha256((str(header) + str(nonce)).encode()).hexdigest()
 
         # check if this is a valid result, below the target
         if long(hash_result, 16) < target:


### PR DESCRIPTION
Python3.x throws an error while computing hash using `hashlib.sha256` library as the Unicode string input needs to be encoded.

Error: `TypeError: Unicode-objects must be encoded before hashing`
Solution: Encoding it to binary. 

It is backward compatible with python2.7.

