### PR TITLE
Stop using numeric_limits for the constant "255", and fix a bug.

### DIFF
--- a/code/vanity-miner.cpp
+++ b/code/vanity-miner.cpp
@@ -45,7 +45,7 @@ bc::ec_secret random_secret(std::default_random_engine& engine)
     bc::ec_secret secret;
     // Iterate through every byte setting a random value...
     for (uint8_t& byte: secret)
-        byte = engine() % std::numeric_limits<uint8_t>::max();
+        byte = engine() & 255;
     // Return result.
     return secret;
 }


### PR DESCRIPTION
The bug is that `x % 255` is not quite the same thing as `x % 256`; but `x & 255` is.

The stylistic issue is that `numeric_limits<uint8_t>::max()` is a very verbose way of spelling `255`.