### PR TITLE
fix double negative typo in example

### DIFF
--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -446,7 +446,7 @@ As we saw in the step-by-step example in <<simplemath_script>>, when this script
 image::images/mbc2_0604.png["TxScriptSimpleMathExample"]
 
 [role="pagebreak-before"]
-The following is a slightly more complex script, which calculates ++2 + 7 -- 3 + 1++. Notice that when the script contains several operators in a row, the stack allows the results of one operator to be acted upon by the next operator:
+The following is a slightly more complex script, which calculates ++2 + 7 - 3 + 1++. Notice that when the script contains several operators in a row, the stack allows the results of one operator to be acted upon by the next operator:
 
 ----
 2 7 OP_ADD 3 OP_SUB 1 OP_ADD 7 OP_EQUAL


### PR DESCRIPTION
the double negative changes the example output to 13 instead of the expected 7