### PR TITLE
Remove "short" from timelock sentence

### DIFF
--- a/ch12.asciidoc
+++ b/ch12.asciidoc
@@ -360,7 +360,7 @@ Output 1:
     <Irene's Public Key> CHECKSIG
 ----
 
-This way, each party has a commitment transaction, spending the 2-of-2 funding output. This input is signed by the _other_ party. At any time the party holding the transaction can also sign (completing the 2-of-2) and broadcast. However, if they broadcast the commitment transaction, it pays the other party immediately whereas they have to wait for a short timelock to expire. By imposing a delay on the redemption of one of the outputs, we put each party at a slight disadvantage when they choose to unilaterally broadcast a commitment transaction. But a time delay alone isn't enough to encourage fair conduct.
+This way, each party has a commitment transaction, spending the 2-of-2 funding output. This input is signed by the _other_ party. At any time the party holding the transaction can also sign (completing the 2-of-2) and broadcast. However, if they broadcast the commitment transaction, it pays the other party immediately whereas they have to wait for a timelock to expire. By imposing a delay on the redemption of one of the outputs, we put each party at a slight disadvantage when they choose to unilaterally broadcast a commitment transaction. But a time delay alone isn't enough to encourage fair conduct.
 
 <<asymmetric_commitments>> shows two asymmetric commitment transactions, where the output paying the holder of the commitment is delayed.
 


### PR DESCRIPTION
I think that short provides an unnecessary detail to the explanation. The timelock can be short or long.

Also, in the provided example, the timelock expires after around 7 days, which may or may not be short.