### PR TITLE
Normalize animals.oreilly.com URL in colophon

### DIFF
--- a/colo.html
+++ b/colo.html
@@ -7,7 +7,7 @@
 
 <p>Once a colony has matured, ants are divided into castes based on size, with each caste performing various functions. There are usually four castes: minims, the smallest workers that tend to the young and fungus gardens; minors, slightly larger than minima, are the first line of defense for the colony and patrol the surrounding terrain and attack enemies; mediae, the general foragers that cut leaves and bring back leaf fragments to the nest; and majors, the largest worker ants that act as soldiers, defending the nest from intruders. Recent research has shown that majors also clear main foraging trails and carry bulky items back to the nest.</p> 
 
-<p>Many of the animals on O'Reilly covers are endangered; all of them are important to the world. To learn more about how you can help, go to <a class="orm:hideurl" href="http://animals.oreilly.com"><em>animals.oreilly.com</em></a>.</p>
+<p>Many of the animals on O'Reilly covers are endangered; all of them are important to the world. To learn more about how you can help, go to <a class="orm:hideurl" href="http://animals.oreilly.com/"><em>animals.oreilly.com</em></a>.</p>
 
 <p>The cover image is from <em>Insects Abroad</em>. The cover fonts are URW Typewriter and Guardian Sans. The text font is Adobe Minion Pro; the heading font is Adobe Myriad Condensed; and the code font is Dalton Maag's Ubuntu Mono.</p>
 </section>


### PR DESCRIPTION
Unfortunately, it doesn't seem that the URL can be changed to use the HTTPS scheme.