### PR TITLE
bitcoin.conf is not created automatically

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -465,7 +465,7 @@ In the next sections we will demonstrate some very useful RPC commands and their
 
 ==== Getting Information on the Bitcoin Core Client Status
 
-((("Bitcoin Core", "Bitcoin Core API", "status information")))Bitcoin Core provides status reports on diffent modules through the JSON-RPC interface. The most important commands include +getblockchaininfo+, +getmempoolinfo+, +getnetworkinfo+ and +getwalletinfo+.
+((("Bitcoin Core", "Bitcoin Core API", "status information")))Bitcoin Core provides status reports on different modules through the JSON-RPC interface. The most important commands include +getblockchaininfo+, +getmempoolinfo+, +getnetworkinfo+ and +getwalletinfo+.
 
 Bitcoin's +getblockchaininfo+ RPC command was introduced earlier. The +getnetworkinfo+ command displays basic information about the status of the bitcoin network node. Use +bitcoin-cli+ to run it:
 

--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -258,7 +258,7 @@ Using config file /home/ubuntu/.bitcoin/bitcoin.conf
 ...
 ----
 
-You can hit Ctrl-C to shut down the node once you determine the location of the config file. Usually the configuration file is inside the _.bitcoin_ data directory under your user's home directory. It is not created automatically so you can create a starter config file by copying and pasting from the <<#full_index_node>> example below. Open the configuration file in your preferred editor.
+You can hit Ctrl-C to shut down the node once you determine the location of the config file. Usually the configuration file is inside the _.bitcoin_ data directory under your user's home directory. It is not created automatically, but you can create a starter config file by copying and pasting from the <<#full_index_node>> example, below. You can create or modify the configuration file in your preferred editor.
 
 Bitcoin Core offers more than 100 configuration options that modify the behavior of the network node, the storage of the blockchain, and many other aspects of its operation. To see a listing of these options, run +bitcoind  --help+:
 

--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -258,7 +258,7 @@ Using config file /home/ubuntu/.bitcoin/bitcoin.conf
 ...
 ----
 
-You can hit Ctrl-C to shut down the node once you determine the location of the config file. Usually the configuration file is inside the _.bitcoin_ data directory under your user's home directory. It is not created automatically so you can create a starter config file by copying and pasting from the [examples below](#full_index_node). Open the configuration file in your preferred editor.
+You can hit Ctrl-C to shut down the node once you determine the location of the config file. Usually the configuration file is inside the _.bitcoin_ data directory under your user's home directory. It is not created automatically so you can create a starter config file by copying and pasting from the <<#full_index_node>> example below. Open the configuration file in your preferred editor.
 
 Bitcoin Core offers more than 100 configuration options that modify the behavior of the network node, the storage of the blockchain, and many other aspects of its operation. To see a listing of these options, run +bitcoind  --help+:
 

--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -258,7 +258,7 @@ Using config file /home/ubuntu/.bitcoin/bitcoin.conf
 ...
 ----
 
-You can hit Ctrl-C to shut down the node once you determine the location of the config file. Usually the configuration file is inside the _.bitcoin_ data directory under your user's home directory. It is not created automatically so you can create a starter config file by copying and pasting from the [examples below](https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch03.asciidoc#full_index_node). Open the configuration file in your preferred editor.
+You can hit Ctrl-C to shut down the node once you determine the location of the config file. Usually the configuration file is inside the _.bitcoin_ data directory under your user's home directory. It is not created automatically so you can create a starter config file by copying and pasting from the [examples below](#full_index_node). Open the configuration file in your preferred editor.
 
 Bitcoin Core offers more than 100 configuration options that modify the behavior of the network node, the storage of the blockchain, and many other aspects of its operation. To see a listing of these options, run +bitcoind  --help+:
 

--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -258,7 +258,7 @@ Using config file /home/ubuntu/.bitcoin/bitcoin.conf
 ...
 ----
 
-You can hit Ctrl-C to shut down the node once you determine the location of the config file. Usually the configuration file is inside the _.bitcoin_ data directory under your user's home directory. Open the configuration file in your preferred editor.
+You can hit Ctrl-C to shut down the node once you determine the location of the config file. Usually the configuration file is inside the _.bitcoin_ data directory under your user's home directory. It is not created automatically so you can create a starter config file using the example [here](https://en.bitcoin.it/wiki/Running_Bitcoin#Bitcoin.conf_Configuration_File). Open the configuration file in your preferred editor.
 
 Bitcoin Core offers more than 100 configuration options that modify the behavior of the network node, the storage of the blockchain, and many other aspects of its operation. To see a listing of these options, run +bitcoind  --help+:
 

--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -258,7 +258,7 @@ Using config file /home/ubuntu/.bitcoin/bitcoin.conf
 ...
 ----
 
-You can hit Ctrl-C to shut down the node once you determine the location of the config file. Usually the configuration file is inside the _.bitcoin_ data directory under your user's home directory. It is not created automatically so you can create a starter config file using the example [here](https://en.bitcoin.it/wiki/Running_Bitcoin#Bitcoin.conf_Configuration_File). Open the configuration file in your preferred editor.
+You can hit Ctrl-C to shut down the node once you determine the location of the config file. Usually the configuration file is inside the _.bitcoin_ data directory under your user's home directory. It is not created automatically so you can create a starter config file uncommenting lines from the example [here](https://en.bitcoin.it/wiki/Running_Bitcoin#Bitcoin.conf_Configuration_File), generate one using the web interface [here](https://jlopp.github.io/bitcoin-core-config-generator/) or copy and past from the examples below. Open the configuration file in your preferred editor.
 
 Bitcoin Core offers more than 100 configuration options that modify the behavior of the network node, the storage of the blockchain, and many other aspects of its operation. To see a listing of these options, run +bitcoind  --help+:
 

--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -258,7 +258,7 @@ Using config file /home/ubuntu/.bitcoin/bitcoin.conf
 ...
 ----
 
-You can hit Ctrl-C to shut down the node once you determine the location of the config file. Usually the configuration file is inside the _.bitcoin_ data directory under your user's home directory. It is not created automatically so you can create a starter config file uncommenting lines from the example [here](https://en.bitcoin.it/wiki/Running_Bitcoin#Bitcoin.conf_Configuration_File), generate one using the web interface [here](https://jlopp.github.io/bitcoin-core-config-generator/) or copy and past from the examples below. Open the configuration file in your preferred editor.
+You can hit Ctrl-C to shut down the node once you determine the location of the config file. Usually the configuration file is inside the _.bitcoin_ data directory under your user's home directory. It is not created automatically so you can create a starter config file by copying and pasting from the [examples below](https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch03.asciidoc#full_index_node). Open the configuration file in your preferred editor.
 
 Bitcoin Core offers more than 100 configuration options that modify the behavior of the network node, the storage of the blockchain, and many other aspects of its operation. To see a listing of these options, run +bitcoind  --help+:
 


### PR DESCRIPTION
The file didn't exist after building and installing the .16 most recent release and according to the documentation in the added [link](https://en.bitcoin.it/wiki/Running_Bitcoin#Bitcoin.conf_Configuration_File) and [bitcoin stackexchange](https://bitcoin.stackexchange.com/questions/11190/where-is-the-configuration-file-of-bitcoin-qt-kept) you are supposed to make it yourself.