### PR TITLE
added byte conversion for mock block string

### DIFF
--- a/code/proof-of-work-example.py
+++ b/code/proof-of-work-example.py
@@ -19,7 +19,8 @@ def proof_of_work(header, difficulty_bits):
     target = 2 ** (256 - difficulty_bits)
 
     for nonce in xrange(max_nonce):
-        hash_result = hashlib.sha256(str(header) + str(nonce)).hexdigest()
+        byte_string = str.encode(header + str(nonce))
+        hash_result = hashlib.sha256(byte_string).hexdigest()
 
         # check if this is a valid result, below the target
         if long(hash_result, 16) < target:


### PR DESCRIPTION
Running the current code in Python 3.6.1 resulted in `TypeError: Unicode-objects must be encoded before hashing` due to the mock block string and integer nonce not being converted to bytes before being hashed.

Corrected by using `str.encode()` on the combined string