### PR TITLE
Fix double equal sign typos not in the original white paper

### DIFF
--- a/appdx-bitcoinwhitepaper.asciidoc
+++ b/appdx-bitcoinwhitepaper.asciidoc
@@ -107,11 +107,11 @@ The race between the honest chain and an attacker chain can be characterized as 
 <p>The probability of an attacker catching up from a given deficit is analogous to a Gambler's Ruin problem. Suppose a gambler with unlimited credit starts at a deficit and plays potentially an infinite number of trials to try to reach breakeven. We can calculate the probability he ever reaches breakeven, or that an attacker ever catches up with the honest chain, as follows <a href="#ref_eight">[8]</a>:</p>
 ++++
 
-p == probability an honest node finds the next block
+p = probability an honest node finds the next block
 
-q == probability the attacker finds the next block
+q = probability the attacker finds the next block
 
-q~z~ == probability the attacker will ever catch up from z blocks behind
+q~z~ = probability the attacker will ever catch up from z blocks behind
 
 image::images/mbc2_abin08.png["eq1"]
 
@@ -140,16 +140,16 @@ Converting to C code...
 #include <math.h>
 double AttackerSuccessProbability(double q, int z)
 {
-    double p == 1.0 - q;
-    double lambda == z * (q / p);
-    double sum == 1.0;
+    double p = 1.0 - q;
+    double lambda = z * (q / p);
+    double sum = 1.0;
     int i, k;
-    for (k == 0; k <== z; k++)
+    for (k = 0; k <= z; k++)
     {
-        double poisson == exp(-lambda);
-        for (i == 1; i <== k; i++)
-            poisson *== lambda / i;
-        sum -== poisson * (1 - pow(q / p, z - k));
+        double poisson = exp(-lambda);
+        for (i = 1; i <= k; i++)
+            poisson *= lambda / i;
+        sum -= poisson * (1 - pow(q / p, z - k));
     }
     return sum;
 }


### PR DESCRIPTION
There were some typos in the white paper appendix where `=` were written `==` unlike in the original white paper.

Corrected to match the original white paper.