### PR TITLE
fixed example in Table 5-6. HD wallet path examples

### DIFF
--- a/ch05.asciidoc
+++ b/ch05.asciidoc
@@ -453,10 +453,10 @@ The "ancestry" of a key is read from right to left, until you reach the master k
 |=======
 |HD path | Key described
 | m/0 | The first (0) child private key from the master private key (m)
-| m/0/0 | The first grandchild private key from the first child (m/0)
-| m/0'/0 | The first normal grandchild from the first _hardened_ child (m/0')
-| m/1/0 | The first grandchild private key from the second child (m/1)
-| M/23/17/0/0 | The first great-great-grandchild public key from the first great-grandchild from the 18th grandchild from the 24th child
+| m/0/0 | The first (0) child private key from the first child (m/0)
+| m/0'/0 | The first (0) normal child from the first _hardened_ child (m/0')
+| m/1/0 | The first (0) child private key from the second child (m/1)
+| M/23/17/0/0 | The first (0) child public key from the first child (M/23/17/0) from the 18th child (M/23/17) from the 24th child (M/23)
 |=======
 
 ===== Navigating the HD wallet tree structure


### PR DESCRIPTION
I explain the reasoning I followed with the second example:
`m/0/0 | The first grandchild private key from the first child (m/0)`

`m/0/0` should be either the first grandchild but from the master private key (m) or the first (0) child from the first child (m/0) from the master key (m). But not the first grandchild from the first child as expressed.

Same reasoning applies to the rest of examples.
