### PR TITLE
Fixed unspent_outputs

### DIFF
--- a/ch02.asciidoc
+++ b/ch02.asciidoc
@@ -168,7 +168,7 @@ $ curl https://blockchain.info/unspent?active=1Cdid9KFAaatwczBwBttQcwXYCpvK8h7FK
 			"tx_hash":"186f9f998a5aa6f048e51dd8419a14d8a0f1a8a2836dd734d2804fe65fa35779",
 			"tx_hash_big_endian:"7957a35fe64f80d234d76d83a2a8f1a0d8149a41d81de548f0a65a8a999f6f18",
 			"tx_index":47852783,
-			"tx_output_n": 1,
+			"tx_output_n": 0,
 			"script":"76a9147f9b1a7fb68d60c536c2fd8aeaa53a8f3cc025a888ac",
 			"value": 10000000,
 			"value_hex": "00989680",

--- a/ch02.asciidoc
+++ b/ch02.asciidoc
@@ -165,9 +165,10 @@ $ curl https://blockchain.info/unspent?active=1Cdid9KFAaatwczBwBttQcwXYCpvK8h7FK
 	"unspent_outputs":[
 
 		{
-			"tx_hash":"186f9f998a5...2836dd734d2804fe65fa35779",
-			"tx_index":104810202,
-			"tx_output_n": 0,
+			"tx_hash":"186f9f998a5aa6f048e51dd8419a14d8a0f1a8a2836dd734d2804fe65fa35779",
+			"tx_hash_big_endian:"7957a35fe64f80d234d76d83a2a8f1a0d8149a41d81de548f0a65a8a999f6f18",
+			"tx_index":47852783,
+			"tx_output_n": 1,
 			"script":"76a9147f9b1a7fb68d60c536c2fd8aeaa53a8f3cc025a888ac",
 			"value": 10000000,
 			"value_hex": "00989680",


### PR DESCRIPTION
Added a new field `tx_hash_big_endian` so it's easier to find the transaction. The transaction here is already spent, but the json here should be consistent with the api response. e.g. https://blockchain.info/unspent?active=1Cdid9KFAaatwczBwBttQcwXYCpvK8h7FK. 

Fixed `tx_index` per https://blockchain.info/rawtx/7957a35fe64f80d234d76d83a2a8f1a0d8149a41d81de548f0a65a8a999f6f18.