### PR TITLE
ch10: Clarify sequence number for typical tx input

### DIFF
--- a/ch10.asciidoc
+++ b/ch10.asciidoc
@@ -307,7 +307,7 @@ As you can see in <<generation_tx_example>>, the coinbase transaction has a spec
 | 4 bytes | Output Index | The index number of the UTXO to be spent, first one is 0
 | 1&#x2013;9 bytes (VarInt) | Unlocking-Script Size | Unlocking-Script length in bytes, to follow
 | Variable | Unlocking-Script | A script that fulfills the conditions of the UTXO locking script
-| 4 bytes | Sequence Number | Currently disabled Tx-replacement feature, set to 0xFFFFFFFF
+| 4 bytes | Sequence Number | Usually set to 0xFFFFFFFF to opt out of BIP 125 and BIP 68
 |=======
 
 [[table_8-2]]

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -224,7 +224,7 @@ Following is a list of notable GitHub contributors, including their GitHub ID in
 * Lucas Betschart (lclc)
 * Magomed Aliev (30mb1)
 * Mai-Hsuan Chia (mhchia)
-* marcofalke
+* Marco Falke (MarcoFalke)
 * Marzig (marzig76)
 * Matt McGivney (mattmcgiv)
 * Maximilian Reichel (phramz)


### PR DESCRIPTION
In chapter 10, it is said that the "Sequence Number" is only used for a "Currently disabled Tx-replacement feature". However, the sequence number is commonly used for BIP 125 and/or BIP 68 signalling. (Though, usually still set to 0xffffffff to opt-out of those BIPs)

See also the corresponding section in `ch07.asciidoc:===== Original meaning of nSequence`