### PR TITLE
Replaces bitly links with full links in Tip boxes

### DIFF
--- a/ch02.asciidoc
+++ b/ch02.asciidoc
@@ -183,7 +183,7 @@ The response in <<example_2-2>> shows one unspent output (one that has not been 
 
 [TIP]
 ====
-View the http://bit.ly/1tAeeGr[transaction from Joe to Alice].
+View the https://www.blockchain.com/btc/tx/7957a35fe64f80d234d76d83a2a8f1a0d8149a41d81de548f0a65a8a999f6f18[transaction from Joe to Alice].
 ====
 
 As you can see, Alice's wallet contains enough bitcoin in a single unspent output to pay for the cup of coffee. Had this not been the case, Alice's wallet application might have to "rummage" through a pile of smaller unspent outputs, like picking coins from a purse until it could find enough to pay for the coffee. In both cases, there might be a need to get some change back, which we will see in the next section, as the wallet application creates the transaction outputs (payments).
@@ -207,7 +207,7 @@ image::images/mbc2_0208.png["Alice Coffee Transaction"]
 [[transaction-alice-url]]
 [TIP]
 ====
-View the http://bit.ly/1u0FIGs[transaction from Alice to Bob's Cafe].
+View the https://www.blockchain.com/btc/tx/0627052b6f28912f2703066a912ea577f2ce4da4caa5a5fbd8a57286c345c2f2[transaction from Alice to Bob's Cafe].
 ====
 
 ==== Adding the Transaction to the Ledger


### PR DESCRIPTION
The bitly links are redirecting to a warning page. 

https://bitly.com/a/warning?hash=1u0FIGs&url=https%3A%2F%2Fblockchain.info%2Ftx%2F0627052b6f28912f2703066a912ea577f2ce4da4caa5a5fbd8a57286c345c2f2