### PR TITLE
Update domain for bitcoinfees website in ch06

### DIFF
--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -304,29 +304,29 @@ Over time, the way transaction fees are calculated and the effect they have on t
 
 Fee estimation algorithms calculate the appropriate fee, based on capacity and the fees offered by "competing" transactions. These algorithms range from simplistic (average or median fee in the last block) to sophisticated (statistical analysis). They estimate the necessary fee (in satoshis per byte) that will give a transaction a high probability of being selected and included within a certain number of blocks. Most services offer users the option of choosing high, medium, or low priority fees. High priority means users pay higher fees but the transaction is likely to be included in the next block. Medium and low priority means users pay lower transaction fees but the transactions may take much longer to confirm.
 
-((("bitcoinfees (third-party service)")))Many wallet applications use third-party services for fee calculations. One popular service is https://bitcoinfees.21.co/[_https://bitcoinfees.21.co/_], which provides an API and a visual chart showing the fee in satoshi/byte for different priorities.
+((("bitcoinfees (third-party service)")))Many wallet applications use third-party services for fee calculations. One popular service is https://bitcoinfees.earn.com/[_https://bitcoinfees.earn.com/_], which provides an API and a visual chart showing the fee in satoshi/byte for different priorities.
 
 [TIP]
 ====
 ((("static fees")))((("fees", "static fees")))Static fees are no longer viable on the bitcoin network. Wallets that set static fees will produce a poor user experience as transactions will often get "stuck" and remain unconfirmed. Users who don't understand bitcoin transactions and fees are dismayed by "stuck" transactions because they think they've lost their money.
 ====
 
-The chart in <<bitcoinfees21co>> shows the real-time estimate of fees in 10 satoshi/byte increments and the expected confirmation time (in minutes and number of blocks) for transactions with fees in each range. For each fee range (e.g., 61&#x2013;70 satoshi/byte), two horizontal bars show the number of unconfirmed transactions (1405) and total number of transactions in the past 24 hours (102,975), with fees in that range. Based on the graph, the recommended high-priority fee at this time was 80 satoshi/byte, a fee likely to result in the transaction being mined in the very next block (zero block delay). For perspective, the median transaction size is 226 bytes, so the recommended fee for a transaction size would be 18,080 satoshis (0.00018080 BTC).
+The chart in <<bitcoinfeesearncom>> shows the real-time estimate of fees in 10 satoshi/byte increments and the expected confirmation time (in minutes and number of blocks) for transactions with fees in each range. For each fee range (e.g., 61&#x2013;70 satoshi/byte), two horizontal bars show the number of unconfirmed transactions (1405) and total number of transactions in the past 24 hours (102,975), with fees in that range. Based on the graph, the recommended high-priority fee at this time was 80 satoshi/byte, a fee likely to result in the transaction being mined in the very next block (zero block delay). For perspective, the median transaction size is 226 bytes, so the recommended fee for a transaction size would be 18,080 satoshis (0.00018080 BTC).
 
-The fee estimation data can be retrieved via a simple HTTP REST API, at https://bitcoinfees.21.co/api/v1/fees/recommended[https://bitcoinfees.21.co/api/v1/fees/recommended]. For example, on the command line using the +curl+ command:
+The fee estimation data can be retrieved via a simple HTTP REST API, at https://bitcoinfees.earn.com/api/v1/fees/recommended[https://bitcoinfees.earn.com/api/v1/fees/recommended]. For example, on the command line using the +curl+ command:
 
 .Using the fee estimation API
 ----
-$ curl https://bitcoinfees.21.co/api/v1/fees/recommended
+$ curl https://bitcoinfees.earn.com/api/v1/fees/recommended
 
 {"fastestFee":80,"halfHourFee":80,"hourFee":60}
 ----
 
 The API returns a JSON object with the current fee estimate for fastest confirmation (+fastestFee+), confirmation within three blocks (+halfHourFee+) and six blocks (+hourFee+), in satoshi per byte.
 
-[[bitcoinfees21co]]
-.Fee estimation service bitcoinfees.21.co
-image::images/mbc2_0602.png[Fee Estimation Service bitcoinfees.21.co]
+[[bitcoinfeesearncom]]
+.Fee estimation service bitcoinfees.earn.com
+image::images/mbc2_0602.png[Fee Estimation Service bitcoinfees.earn.com]
 
 ==== Adding Fees to Transactions
 


### PR DESCRIPTION
Fixes #634.

I've updated the domain from https://bitcoinfees.21.co to https://bitcoinfees.earn.com. This includes the links, the `curl` command example and the Figure 2 label and its bookmark.
