### PR TITLE
Note should be a warning

### DIFF
--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -594,7 +594,7 @@ include::code/ec-math.py[]
 
 <<ec_math_run>> shows the output produced by running this script.
 
-[NOTE]
+[WARNING]
 ====
 <<ec_math>> ((("random numbers", "os.urandom", see="entropy")))((("entropy", "os.urandom", see="random numbers")))((("random numbers", "random number generation")))((("entropy", "random number generation")))uses +os.urandom+, which reflects a cryptographically secure random number generator (CSRNG) provided by the underlying operating system. Caution: Depending on the OS, +os.urandom+ may _not_ be implemented with sufficient security or seeded properly and may _not_ be appropriate for generating production-quality bitcoin keys.((("", startref="KApython04")))
 ====


### PR DESCRIPTION
The main point of the paragraph appears to be not to use `os.urandom` for production, so making it a warning seems a better fit than a note.