### PR TITLE
Change parameter block->blocks in description to match code

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -690,7 +690,7 @@ If you're implementing a JSON-RPC call in your own program, you can use a generi
 
 However, there are libraries in most every programming language that "wrap" the Bitcoin Core API in a way that makes this a lot simpler. We will use the +python-bitcoinlib+ library to simplify API access. Remember, this requires you to have a running Bitcoin Core instance, which will be used to make JSON-RPC calls.
 
-The Python script in <<rpc_example>> makes a simple +getblockchaininfo+ call and prints the +block+ parameter from the data returned by Bitcoin Core.
+The Python script in <<rpc_example>> makes a simple +getblockchaininfo+ call and prints the +blocks+ parameter from the data returned by Bitcoin Core.
 
 [[rpc_example]]
 .Running getblockchaininfo via Bitcoin Core's JSON-RPC API


### PR DESCRIPTION
The example gets the `blocks` parameter. The preceding description says it takes the `block` parameter. This seems to be a typo.