### PR TITLE
[ch6] Use n instead of p for group order of EC

### DIFF
--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -650,7 +650,7 @@ The temporary key pair is based on a random number _k_, which is used as the tem
 
 From there, the algorithm calculates the _S_ value of the signature, such that:
 
-_S_ = __k__^-1^ (__Hash__(__m__) + __dA__ * __R__) _mod p_
+_S_ = __k__^-1^ (__Hash__(__m__) + __dA__ * __R__) _mod n_
 
 where:
 
@@ -658,7 +658,7 @@ where:
 * _R_ is the x coordinate of the ephemeral public key
 * _dA_ is the signing private key
 * _m_ is the transaction data
-* _p_ is the prime order of the elliptic curve
+* _n_ is the prime order of the elliptic curve
 
 Verification is the inverse of the signature generation function, using the _R_, _S_ values and the public key to calculate a value _P_, which is a point on the elliptic curve (the ephemeral public key used in signature creation):
 


### PR DESCRIPTION
This is to match existing common conventions.
By convention, n, not p, is used to indicate the prime group order of the EC.
This is currently extra confusing because p *is* (by convention) used to indicate the order of the EC's finite field.

References:
https://github.com/bitcoin-core/secp256k1/blob/master/src/ecdsa_impl.h
http://www.secg.org/sec2-v2.pdf
https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm