### PR TITLE
Remove unneeded env var declaration

### DIFF
--- a/appdx-bitcore.asciidoc
+++ b/appdx-bitcore.asciidoc
@@ -32,7 +32,6 @@ If using NodeJS and the node REPL:
 [source,bash]
 ----
 $ npm install -g bitcore-lib bitcore-p2p
-$ NODE_PATH=$(npm list -g | head -1)/node_modules node
 ----
 
 ==== Wallet Examples using bitcore-lib


### PR DESCRIPTION
The NODE_PATH is not needed to run these examples. Also this is an unreliable way to set the environment variable anyway (didn't work for me).