### PR TITLE
Update key-to-address-ecc-example.py

### DIFF
--- a/code/key-to-address-ecc-example.py
+++ b/code/key-to-address-ecc-example.py
@@ -21,7 +21,7 @@ print("Private Key Compressed (hex) is: ", compressed_private_key)
 
 # Generate a WIF format from the compressed private key (WIF-compressed)
 wif_compressed_private_key = bitcoin.encode_privkey(
-    bitcoin.decode_privkey(compressed_private_key, 'hex'), 'wif_compressed')
+    bitcoin.decode_privkey(compressed_private_key, 'hex'), 'wif')
 print("Private Key (WIF-Compressed) is: ", wif_compressed_private_key)
 
 # Multiply the EC generator point G with the private key to get a public key point


### PR DESCRIPTION
If line#24 use 'wif_compressed', it will produce a wrong Key (WIF-Compressed) started with 2.

So there should be 'wif', unless :

wif_compressed_private_key = bitcoin.encode_privkey(
    bitcoin.decode_privkey(private_key, 'hex'), 'wif_compressed')

This is also right. 

However, use the 'compressed_private_key' and 'wif_compressed' is wrong.