### PR TITLE
Replace OpenSSL with secp265k1

### DIFF
--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -236,7 +236,7 @@ To visualize multiplication of a point with an integer, we will use the simpler 
 
 [TIP]
 ====
-((("secp256k1 C library")))Bitcoin usees the https://github.com/bitcoin-core/secp256k1[secp256k1 C library] to do the elliptic curve math. For example, to derive the public key, the function +EC_POINT_mul()+ is used.((("", startref="KAover04")))
+((("secp256k1 optimized C library")))Bitcoin uses the https://github.com/bitcoin-core/secp256k1[secp256k1 optimized C library] to do the elliptic curve math. For example, to derive the public key, the function +EC_POINT_mul()+ is used.((("", startref="KAover04")))
 ====
 
 [[ecc_illustrated]]

--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -236,7 +236,7 @@ To visualize multiplication of a point with an integer, we will use the simpler 
 
 [TIP]
 ====
-((("OpenSSL cryptographic library")))Most bitcoin implementations use the http://bit.ly/1ql7bn8[OpenSSL cryptographic library] to do the elliptic curve math. For example, to derive the public key, the function +EC_POINT_mul()+ is used.((("", startref="KAover04")))
+((("secp256k1 C library")))Bitcoin usees the https://github.com/bitcoin-core/secp256k1[secp256k1 C library] to do the elliptic curve math. For example, to derive the public key, the function +EC_POINT_mul()+ is used.((("", startref="KAover04")))
 ====
 
 [[ecc_illustrated]]


### PR DESCRIPTION
According to the tweet https://twitter.com/aantonop/status/1255853793805287429 I replaced OpenSSL with secp265k1 and point to the bitcoin core github repository. Feel free to generate your bit.ly url. My name is Tri Nhan Vu focussing on blockchain education for german speaking people https://chainist.de/.