### PR TITLE
Fix OP_CHECKMULTISIG workaround

### DIFF
--- a/appdx-scriptops.asciidoc
+++ b/appdx-scriptops.asciidoc
@@ -168,7 +168,7 @@ Tables and descriptions sourced from https://en.bitcoin.it/wiki/Script[].
 | OP_CODESEPARATOR | 0xab | Mark the beginning of signature-checked data
 | OP_CHECKSIG | 0xac | Pop a public key and signature and validate the signature for the transaction's hashed data, return TRUE if matching
 | OP_CHECKSIGVERIFY | 0xad | Same as CHECKSIG, then OP_VERIFY to halt if not TRUE
-| OP_CHECKMULTISIG | 0xae | Run CHECKSIG for each pair of signature and public key provided. All must match. Bug in implementation pops an extra value, prefix with OP_NOP as workaround
+| OP_CHECKMULTISIG | 0xae | Run CHECKSIG for each pair of signature and public key provided. All must match. Bug in implementation pops an extra value, prefix with OP_0 as workaround
 | OP_CHECKMULTISIGVERIFY | 0xaf | Same as CHECKMULTISIG, then OP_VERIFY to halt if not TRUE
 |=======
 


### PR DESCRIPTION
The OP_CHECKMULTISIG workaround requires an extra element to be pushed onto the stack. OP_NOP does not push anything onto the stack but OP_0 does.
