### PR TITLE
ch03: Update link to rust implementation

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -789,7 +789,7 @@ https://github.com/sinisterchipmunk/bitcoin-client[bitcoin-client]:: A Ruby libr
 https://github.com/btcsuite/btcd[btcd]:: A Go language full-node bitcoin client
 
 ==== Rust
-https://github.com/apoelstra/rust-bitcoin[rust-bitcoin]:: Rust bitcoin library for serialization, parsing, and API calls
+https://github.com/rust-bitcoin/rust-bitcoin[rust-bitcoin]:: Rust bitcoin library for serialization, parsing, and API calls
 
 ==== C#
 https://github.com/MetacoSA/NBitcoin[NBitcoin]:: Comprehensive bitcoin library for the .NET framework


### PR DESCRIPTION
Old link refers to what seems to be a fork.
Repo at https://github.com/rust-bitcoin/rust-bitcoin
is much more popular and maintained.