### PR TITLE
Update links on resources

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -761,18 +761,17 @@ The following sections list some of the best libraries, clients, and toolkits, o
 
 ==== C/C++
 https://github.com/bitcoin/bitcoin[Bitcoin Core] :: The reference implementation of bitcoin
-https://github.com/libbitcoin/libbitcoin[libbitcoin]:: Cross-platform C++ development toolkit, node, and consensus library
+https://github.com/libbitcoin/libbitcoin-system[libbitcoin]:: Cross-platform C++ development toolkit, node, and consensus library
 https://github.com/libbitcoin/libbitcoin-explorer[bitcoin explorer]:: Libbitcoin's command-line tool
 https://github.com/jgarzik/picocoin[picocoin]:: A C language lightweight client library for bitcoin by Jeff Garzik
 
 ==== JavaScript
-http://bcoin.io/[bcoin]:: A modular and scalable full-node implementation with API
+https://bcoin.io/[bcoin]:: A modular and scalable full-node implementation with API
 https://bitcore.io/[Bitcore] :: Full node, API, and library by Bitpay
 https://github.com/bitcoinjs/bitcoinjs-lib[BitcoinJS] :: A pure JavaScript Bitcoin library for node.js and browsers
 
 ==== Java
 https://bitcoinj.github.io[bitcoinj]:: A Java full-node client library
-https://bitsofproof.com[Bits of Proof (BOP)]:: A Java enterprise-class implementation of bitcoin
 
 ==== PHP
 https://github.com/bit-wasp/bitcoin-php[bitwasp/bitcoin]:: A PHP bitcoin library, and related projects
@@ -780,7 +779,7 @@ https://github.com/bit-wasp/bitcoin-php[bitwasp/bitcoin]:: A PHP bitcoin library
 ==== Python
 https://github.com/petertodd/python-bitcoinlib[python-bitcoinlib]::  A Python bitcoin library, consensus library, and node by Peter Todd
 https://github.com/richardkiss/pycoin[pycoin]:: A Python bitcoin library by Richard Kiss
-https://github.com/vbuterin/pybitcointools[pybitcointools]:: A Python bitcoin library by Vitalik Buterin
+https://github.com/primal100/pybitcointools[pybitcointools]:: An archieved fork Python bitcoin library by Vitalik Buterin
 
 ==== Ruby
 https://github.com/sinisterchipmunk/bitcoin-client[bitcoin-client]:: A Ruby library wrapper for the JSON-RPC API


### PR DESCRIPTION
- Update link to new libbitcoin repo
- https for bcoin
- Remove Bits of Proof, whose site was purchased
- Update the link to the fork of pybitcointools that was maintained by the community after Vitalik ended support