### PR TITLE
Correct transaction costs in segwit example

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -1023,25 +1023,25 @@ The incentives created by fees matter because they affect the behavior of wallet
 
 Transactions consume UTXO in their inputs and create new UTXO with their outputs. A transaction, therefore, that has more inputs than outputs will result in a decrease in the UTXO set, whereas a transaction that has more outputs than inputs will result in an increase in the UTXO set. Let’s consider the _difference_ between inputs and outputs and call that the “Net-new-UTXO.” That’s an important metric, as it tells us what impact a transaction will have on the most expensive network-wide resource, the in-memory UTXO set. A transaction with positive Net-new-UTXO adds to that burden. A transaction with a negative Net-new-UTXO reduces the burden. We would therefore want to encourage transactions that are either negative Net-new-UTXO or neutral with zero Net-new-UTXO.
 
-Let’s look at an example of what incentives are created by the transaction fee calculation, with and without Segregated Witness. We will look at two different transactions. Transaction A is a 3-input, 2-output transaction, which has a Net-new-UTXO metric of &#x2013;1, meaning it consumes one more UTXO than it creates, reducing the UTXO set by one. Transaction B is a 2-input, 3-output transaction, which has a Net-new-UTXO metric of 1, meaning it adds one UTXO to the UTXO set, imposing additional cost on the entire bitcoin network. Both transactions use multisignature (2-of-3) scripts to demonstrate how complex scripts increase the impact of segregated witness on fees. Let’s assume a transaction fee of 30 satoshi per byte and a 75% fee discount on witness data:
+Let’s look at an example of what incentives are created by the transaction fee calculation, with and without Segregated Witness. We will look at two different transactions. Transaction A is a 3-input, 2-output transaction, which has a Net-new-UTXO metric of &#x2013;1, meaning it consumes one more UTXO than it creates, reducing the UTXO set by one. Transaction B is a 2-input, 3-output transaction, which has a Net-new-UTXO metric of 1, meaning it adds one UTXO to the UTXO set, imposing additional cost on the entire bitcoin network. Both transactions use multisignature (2-of-3) scripts to demonstrate how complex scripts increase the impact of segregated witness on fees. Let’s assume a transaction feerate of 30 satoshi per byte and a 75% fee discount on witness data:
 
 ++++
 <dl>
 <dt>Without Segregated Witness</dt>
 <dd>
-<p>Transaction A fee: 25,710 satoshi</p>
-<p>Transaction B fee: 18,990 satoshi</p>
+<p>Transaction A fee: 28,590 satoshi</p>
+<p>Transaction B fee: 20,760 satoshi</p>
 </dd>
 
 <dt>With Segregated Witness</dt>
 <dd>
-<p>Transaction A fee: 8,130 satoshi</p>
-<p>Transaction B fee: 12,045 satoshi</p>
+<p>Transaction A fee: 12,255 satoshi</p>
+<p>Transaction B fee: 10,425 satoshi</p>
 </dd>
 </dl>
 ++++
 
 
-Both transactions are less expensive when segregated witness is implemented. But comparing the costs between the two transactions, we see that before Segregated Witness, the fee is higher for the transaction that has a negative Net-new-UTXO. After Segregated Witness, the transaction fees align with the incentive to minimize new UTXO creation by not inadvertently penalizing transactions with many inputs.
+Both transactions are less expensive when segregated witness is implemented. Comparing the costs between the two transactions, we see that before Segregated Witness, the transaction with the positive Net-new-UTXO has significant cost-savings. With Segregated Witness, the cost difference shrinks significantly in absolute as well as relative terms. While it would require inputs to become cheaper than outputs to incentivize UTXO set consolidation, this discount reduces the incentive to create new UTXO in order to avoid using more inputs.
 
-Segregated Witness therefore has two main effects on the fees paid by bitcoin users. Firstly, segwit reduces the overall cost of transactions by discounting witness data and increasing the capacity of the bitcoin blockchain. Secondly, segwit’s discount on witness data corrects a misalignment of incentives that may have inadvertently created more bloat in the UTXO set.((("", startref="Tadv07")))((("", startref="Ssegwit07")))
+Segregated Witness therefore has two main effects on the fees paid by bitcoin users. Firstly, segwit reduces the overall cost of transactions by discounting witness data and increasing the capacity of the bitcoin blockchain. Secondly, segwit’s discount on witness data partially mitigates a misalignment of incentives that may have inadvertently created more bloat in the UTXO set.((("", startref="Tadv07")))((("", startref="Ssegwit07")))


### PR DESCRIPTION
The transaction fees in the example were off.
2-of-3 P2SH inputs are between 293 and 297 bytes (293 bytes if both
signatures have low-R, 296 bytes if one signature has high-R, 297 bytes
if both signatures have high-R) and P2SH outputs are 32 bytes.

2-of-3 P2WSH (native segwit) inputs are between 104 and 104.5 vbytes
(416–418 WU, depending on low-R/high-R as above) and P2WSH outputs are
43 bytes.

The transaction header has 10 bytes for non-segwit transactions and 42
WU for segwit transactions.

Source:
https://github.com/BitGo/unspents/blob/master/src/dimensions.ts#L69

I have updated the numbers in the example and amended the conclusion
which did not match the new numbers. Calculation details follow.

-----

Let's assume that the wallet is using signature grinding and will always
produce signatures with low-R:

•Without Segregated Witness:
Transaction A using 2-of-3 P2SH inputs and P2SH outputs:
3\*293 + 10 + 2\*32 = 953
953 \* 30 = 28,590

Transaction B using 2-of-3 P2SH inputs and P2SH outputs:
2\*293 + 10 + 3\*32 = 692
692 \* 30 = 20,760

•With Segregated Witness:
Transaction A using 2-of-3 P2WSH (native segwit) inputs and outputs:
3\*104 + 10.5 + 2\*43 = 408.5
408.5 \* 30 = 12,255

Transaction B using 2-of-3 P2WSH (native segwit) inputs and P2WSH
outputs:
2\*104 + 10.5 + 3\*43 = 347.5
347.5 \* 30 = 10,425