### PR TITLE
ch10: delete 'no longer'; clarify 'forward' word

### DIFF
--- a/ch10.asciidoc
+++ b/ch10.asciidoc
@@ -949,7 +949,7 @@ While the consensus rules are invariable in the short term and must be consisten
 
 There is another scenario in which the network may diverge into following two chains: a change in the consensus rules. This type of fork is called a _hard fork_, because after the fork the network does not reconverge onto a single chain. Instead, the two chains evolve independently. Hard forks occur when part of the network is operating under a different set of consensus rules than the rest of the network. This may occur because of a bug or because of a deliberate change in the implementation of the consensus rules.
 
-Hard forks can be used to change the rules of consensus, but they require coordination between all participants in the system. Any nodes that do not upgrade to the new consensus rules are unable to participate in the consensus mechanism and are forced onto a separate chain at the moment of the hard fork. Thus, a change introduced by a hard fork can be thought of as not "forward compatible," in that nonupgraded systems can no longer process the new consensus rules.
+Hard forks can be used to change the rules of consensus, but they require coordination between all participants in the system. Any nodes that do not upgrade to the new consensus rules are unable to participate in the consensus mechanism and are forced onto a separate chain at the moment of the hard fork. Thus, a change introduced by a hard fork can be thought of as not "forward compatible," in that nonupgraded systems can't process the new consensus rules after the hard fork event.
 
 Let's examine the mechanics of a hard fork with a specific example.
 


### PR DESCRIPTION
1. 'no longer' is wrong here, because the nonupgraded systems were/are never able to process the new rules (both before and after the hard fork event).
2. Clarify that the 'forward' word means in relation to the hard fork _event_.