### PR TITLE
ch04: Fix mathematical terms

### DIFF
--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -110,7 +110,7 @@ $ bx seed | bx ec-new | bx ec-to-wif
 
 [TIP]
 ====
-Elliptic curve multiplication is a type of function that cryptographers call a "trap door" function: it is easy to do in one direction (multiplication) and impossible to do in the reverse direction (division). The owner of the private key can easily create the public key and then share it with the world knowing that no one can reverse the function and calculate the private key from the public key. This mathematical trick becomes the basis for unforgeable and secure digital signatures that prove ownership of bitcoin funds.
+Elliptic curve multiplication is a type of function that cryptographers call a "one-way" function: it is easy to do in one direction (multiplication) and impossible to do in the reverse direction ("division", or finding the discrete logarithm). The owner of the private key can easily create the public key and then share it with the world knowing that no one can reverse the function and calculate the private key from the public key. This mathematical trick becomes the basis for unforgeable and secure digital signatures that prove ownership of bitcoin funds.
 ====
 
 [[elliptic_curve]]


### PR DESCRIPTION
1. EC multiplication is a "one-way" function, not a "trapdoor" one. There is no information that makes reverse function easy. See:
  - https://en.wikipedia.org/wiki/Trapdoor_function
  - https://en.wikipedia.org/wiki/One-way_function

2. The "discrete logarithm" is more usual term for the reverse operation for EC multiplication.