### PR TITLE
450 MiB is now the default cache size (ch. 3)

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -300,7 +300,7 @@ prune:: Reduce the disk space requirements to this many megabytes, by deleting o
 
 txindex:: Maintain an index of all transactions. This means a complete copy of the blockchain that allows you to programmatically retrieve any transaction by ID.
 
-dbcache:: The size of the UTXO cache. The default is 300 MiB. Increase this on high-end hardware and reduce the size on low-end hardware to save memory at the expense of slow disk IO.
+dbcache:: The size of the UTXO cache. The default is 450 MiB. Increase this on high-end hardware and reduce the size on low-end hardware to save memory at the expense of slow disk IO.
 
 maxconnections:: Set the maximum number of nodes from which to accept connections. Reducing this from the default will reduce your bandwidth consumption. Use if you have a data cap or pay by the gigabyte.
 


### PR DESCRIPTION
The default cache size is now 450 MiB on the most recent release (0.20.1)