### PR TITLE
chp04: xref <<vanity_minor_code>> seems better for note on std:random…

### DIFF
--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -713,7 +713,7 @@ include::code/vanity-miner.cpp[]
 
 [NOTE]
 ====
-<<vanity_miner_run>> uses +std::random_device+. Depending on the implementation it may reflect a CSRNG provided by the underlying operating system. In the case of a Unix-like operating system such as Linux, it draws from +/dev/urandom+. The random number generator used here is for demonstration purposes, and it is _not_ appropriate for generating production-quality bitcoin keys as it is not implemented with sufficient security.
+<<vanity_miner_code>> uses +std::random_device+. Depending on the implementation it may reflect a CSRNG provided by the underlying operating system. In the case of a Unix-like operating system such as Linux, it draws from +/dev/urandom+. The random number generator used here is for demonstration purposes, and it is _not_ appropriate for generating production-quality bitcoin keys as it is not implemented with sufficient security.
 ====
 
 The example code must be compiled using a pass:[C++] compiler and linked against the libbitcoin library (which must be first installed on that system). To run the example, run the ++vanity-miner++ executable with no parameters (see <<vanity_miner_run>>) and it will attempt to find a vanity address starting with "1kid."


### PR DESCRIPTION
…_device

Because 'std::random_device' appears in xref vanity_miner_code as opposed to xref vanity_miner_run, it feels more appropriate to use the former in this note.