### PR TITLE
Node X is incorrectly referenced as a randomly chosen node.

### DIFF
--- a/ch10.asciidoc
+++ b/ch10.asciidoc
@@ -799,7 +799,7 @@ As the two blocks propagate, some nodes receive block "triangle" first and some 
 .Visualization of a blockchain fork event: two blocks propagate, splitting the network
 image::images/mbc2_1004.png["Visualization of a blockchain fork event: two blocks propagate, splitting the network"]
 
-In the diagram, a randomly chosen "Node X" received the triangle block first and extended the star chain with it. Node X selected the chain with "triangle" block as the main chain. Later, Node X also received the "upside-down triangle" block. Since it was received second, it is assumed to have "lost" the race. Yet, the "upside-down triangle" block is not discarded. It is linked to the "star" block parent and forms a secondary chain. While Node X assumes it has correctly selected the winning chain, it keeps the "losing" chain so that it has the information needed to reconverge if the "losing" chain ends up "winning."
+Later, Node X also received the "upside-down triangle" block. Since it was received second, it is assumed to have "lost" the race. Yet, the "upside-down triangle" block is not discarded. It is linked to the "star" block parent and forms a secondary chain. While Node X assumes it has correctly selected the winning chain, it keeps the "losing" chain so that it has the information needed to reconverge if the "losing" chain ends up "winning."
 
 On the other side of the network, Node Y constructs a blockchain based on its own perspective of the sequence of events. It received "upside-down triangle" first and elected that chain as the "winner." When it later received "triangle" block, it connected it to the "star" block parent as a secondary chain.
 


### PR DESCRIPTION
Node X is responsible for producing the triangle block. The original
wording implies that Node X did not mine the block, but received it
from some other node.