### PR TITLE
glossary: fixing multisig explanation

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -120,7 +120,7 @@ miner::
     A network node that finds valid proof of work for new blocks, by repeated hashing.
 
 multisignature::
-    Multisignature (multisig) refers to requiring more than one key to authorize a bitcoin transaction.
+    Multisignature (multisig) refers to requiring a minimum number (M) of keys (N) to authorize an M-of-N transaction.
 
 network::
     A peer-to-peer network that propagates transactions and blocks to every bitcoin node on the network.


### PR DESCRIPTION
Current explanation is wrong, since multisig can be 1-of-2.