### PR TITLE
ch06: preceding input->input from Alice's transaction; change UTXO example…

### DIFF
--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -210,10 +210,10 @@ It's not just Alice's wallet that needs to retrieve UTXO referenced in the input
 
 Transactions on their own seem incomplete because they lack context. They reference UTXO in their inputs but without retrieving that UTXO we cannot know the value of the inputs or their locking conditions. When writing bitcoin software, anytime you decode a transaction with the intent of validating it or counting the fees or checking the unlocking script, your code will first have to retrieve the referenced UTXO from the blockchain in order to build the context implied but not present in the UTXO references of the inputs. For example, to calculate the amount paid in fees, you must know the sum of the values of inputs and outputs. But without retrieving the UTXO referenced in the inputs, you do not know their value. So a seemingly simple operation like counting fees in a single transaction in fact involves multiple steps and data from multiple transactions.
 
-We can use the same sequence of commands with Bitcoin Core as we used when retrieving Alice's transaction (+getrawtransaction+ and +decoderawtransaction+). With that we can get the UTXO referenced in the preceding input and take a look:
+We can use the same sequence of commands with Bitcoin Core as we used when retrieving Alice's transaction (+getrawtransaction+ and +decoderawtransaction+). With that we can get the UTXO referenced in the input from Alice's transaction and take a look:
 
 [[alice_input_tx]]
-.Alice's UTXO from the previous transaction, referenced in the input
+.UTXO from the previous transaction, referenced in the input from Alice's transaction
 [source,json]
 ----
 "vout": [


### PR DESCRIPTION
… caption

1) changed text 
from
`UTXO referenced in the preceding input...`
to
`UTXO referenced in the input from Alice's transaction...`
because the input which contains the referenced UTXO is not from a previous/preceding transaction (Joe pays to Alice), it's from the current Alice's transaction (Alice pays to Bob)

2) changed UTXO example caption 
from
`Alice's UTXO from the previous transaction, referenced in the input`
to
`UTXO from the previous transaction, referenced in the input from Alice's transaction`

because it's easier to understand