### PR TITLE
Update ch04.asciidoc - consistency with hexadecimal and bytes 

### DIFF
--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -342,7 +342,7 @@ In bitcoin, most of the data presented to the user is Base58Check-encoded to mak
 |Type|Prefix|Description
 | Raw | None | 32 bytes
 | Hex | None | 64 hexadecimal digits
-| WIF |  5 | Base58Check encoding: Base58 with version prefix of 128- and 32-bit checksum
+| WIF |  5 | Base58Check encoding: Base58 with version prefix of 0x80 and 4-byte checksum
 | WIF-compressed | K or L | As above, with added suffix 0x01 before encoding
 |=======
 


### PR DESCRIPTION
Values changed to hexadecimal and bytes to maintain consistency with across graphs and images in this chapter.