### PR TITLE
ch07: fix numbered list; lock-time -> timelock

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -317,10 +317,10 @@ Bob's transaction is evaluated as follows. If the +CHECKLOCKTIMEVERIFY+ paramete
 More precisely, +CHECKLOCKTIMEVERIFY+ fails and halts execution, marking the transaction invalid if (source: BIP-65):
 
 1. the stack is empty; or
-1. the top item on the stack is less than 0; or
-1. the lock-time type (height versus timestamp) of the top stack item and the +nLocktime+ field are not the same; or
-1. the top stack item is greater than the transaction's +nLocktime+ field; or
-1. the +nSequence+ field of the input is 0xffffffff.
+2. the top item on the stack is less than 0; or
+3. the timelock type (height versus timestamp) of the top stack item and the +nLocktime+ field are not the same; or
+4. the top stack item is greater than the transaction's +nLocktime+ field; or
+5. the +nSequence+ field of the input is 0xffffffff.
 
 [NOTE]
 ====


### PR DESCRIPTION
"lock-time" is used in BIPs, but "timelock" is used in Mastering Bitcoin instead