### PR TITLE
ch07: change order of signers; add "the Lawyer" to Abdul's sig

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -604,7 +604,7 @@ The second execution path can only be used after 30 days have elapsed from the c
 
 .Unlocking script for the second execution path (Lawyer + 1-of-3)
 ----
-0 <Saeed's Sig> <Abdul's Sig> FALSE TRUE
+0 <Abdul the Lawyer's Sig> <Saeed's Sig> FALSE TRUE
 ----
 
 [TIP]
@@ -616,7 +616,7 @@ Finally, the third execution path allows Abdul the lawyer to spend the funds alo
 
 .Unlocking script for the third execution path (Lawyer only)
 ----
-<Abdul's Sig> FALSE
+<Abdul the Lawyer's Sig> FALSE
 ----
 
 Try running the script on paper to see how it behaves on the stack.


### PR DESCRIPTION
In the text and the example caption, Abdul the lawyer signs first:

> The second execution path can only be used after 30 days have elapsed from the creation of the UTXO. At that time, it requires **the signature of Abdul the lawyer and one of the three partners (a 1-of-3 multisig)**. 

> Unlocking script for the second execution path (**Lawyer + 1-of-3**)

I'm not sure if changing the order of signatures breaks the code, if so, the text and caption should be modified to "1-of-3 + Lawyer".

This PR also adds "the Lawyer" to Abdul's sig