### PR TITLE
Update ch07.asciidoc - Removed Public Key for unlocking script for P2SH

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -30,12 +30,11 @@ A locking script setting a 2-of-3 multisignature condition looks like this:
 2 <Public Key A> <Public Key B> <Public Key C> 3 CHECKMULTISIG
 ----
 
-The preceding locking script can be satisfied with an unlocking script containing pairs of signatures and public keys:
+The preceding locking script can be satisfied with an unlocking script containing any combination of two signatures from the private keys corresponding to the three listed public keys:
 
 ----
 <Signature B> <Signature C>
 ----
-or any combination of two signatures from the private keys corresponding to the three listed public keys.
 
 The two scripts together would form the combined validation script:
 


### PR DESCRIPTION
Updated the P2SH unlocking script to state that just signatures are required to satisfy unlocking conditions, as depicted by the examples. Removed statement regarding how public keys are needed for unlocking condition. 