### PR TITLE
ch06 - Added ScriptSig serialization table for completeness

### DIFF
--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -285,7 +285,7 @@ Hints:
 * The length of the +scriptSig+ is 139 bytes, or +8b+ in hex
 * The sequence number is set to +FFFFFFFF+, again easy to identify((("", startref="alicesix")))
 
-When scriptSigs are serialized for transmission on the network, their inputs are encoded into a byte stream as shown in <<scriptsig_in_structure>>.
+When scriptSigs are serialized for transmission on the network, their inputs are encoded into a byte stream as shown in <<scriptsig_in_structure>>. The serialization of the signature portion is further elaborated on in <<seralization_of_signatures_der>>. This portion includes a Signature Hash Type (SIGHASH), which is detailed in <<sighash_types>>.
 
 [[scriptsig_in_structure]]
 .ScriptSig input serialization

--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -285,7 +285,7 @@ Hints:
 * The length of the +scriptSig+ is 139 bytes, or +8b+ in hex
 * The sequence number is set to +FFFFFFFF+, again easy to identify((("", startref="alicesix")))
 
-When scriptSigs are serialized for transmission on the network, their inputs are encoded into a byte stream as shown in <<scriptsig_in_structure>>. The serialization of the signature portion is further elaborated on in <<seralization_of_signatures_der>>. This portion includes a Signature Hash Type (SIGHASH), which is detailed in <<sighash_types>>.
+When scriptSigs are serialized for transmission on the network, their inputs are encoded into a byte stream as shown in <<scriptsig_in_structure>>. The serialization of the signature field is detailed in <<seralization_of_signatures_der>>. The signature field also includes a Signature Hash Type (SIGHASH), which is detailed in <<sighash_types>>.
 
 [[scriptsig_in_structure]]
 .ScriptSig input serialization
@@ -295,7 +295,7 @@ When scriptSigs are serialized for transmission on the network, their inputs are
 | 1&#x2013;9 bytes (VarInt) | Signature Size | Signature length in bytes, to follow
 | Variable | Signature | A signature that is produced by the user’s wallet from his or her private key, which includes a SIGHASH
 | 1&#x2013;9 bytes (VarInt) | Public Key Size | Public key length in bytes, to follow
-| Variable | Public Key | The public key, which is equivalent to a bitcoin address, without the Base58Check encoding
+| Variable | Public Key | The public key, unhashed
 |=======
 
 [[tx_fees]]

--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -285,7 +285,7 @@ Hints:
 * The length of the +scriptSig+ is 139 bytes, or +8b+ in hex
 * The sequence number is set to +FFFFFFFF+, again easy to identify((("", startref="alicesix")))
 
-When scriptSigs are serialized for transmission on the network, their inputs are encoded into a byte stream as shown in <<scriptsig_in_structure>>. The serialization of the signature field is detailed in <<seralization_of_signatures_der>>. The signature field also includes a Signature Hash Type (SIGHASH), which is detailed in <<sighash_types>>.
+ScriptSig is a specific type of unlocking script that when serialized for transmission on the network, inputs are encoded into a byte stream as shown in <<scriptsig_in_structure>>. The serialization of the signature field is detailed in <<seralization_of_signatures_der>>. The signature field also includes a Signature Hash Type (SIGHASH), which is detailed in <<sighash_types>>.
 
 [[scriptsig_in_structure]]
 .ScriptSig input serialization

--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -285,6 +285,19 @@ Hints:
 * The length of the +scriptSig+ is 139 bytes, or +8b+ in hex
 * The sequence number is set to +FFFFFFFF+, again easy to identify((("", startref="alicesix")))
 
+When scriptSigs are serialized for transmission on the network, their inputs are encoded into a byte stream as shown in <<ScriptSig input serialization>>.
+
+[[tx_in_structure]]
+.ScriptSig input serialization
+[options="header"]
+|=======
+|Size| Field | Description
+| 1&#x2013;9 bytes (VarInt) | Signature Size | Signature length in bytes, to follow
+| Variable | Signature | A signature that is produced by the user’s wallet from his or her private key, which includes a SIGHASH
+| 1&#x2013;9 bytes (VarInt) | Public Key Size | Public key length in bytes, to follow
+| Variable | Public Key | The public key, which is equivalent to a bitcoin address, without the Base58Check encoding
+|=======
+
 [[tx_fees]]
 ==== Transaction Fees
 

--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -285,9 +285,9 @@ Hints:
 * The length of the +scriptSig+ is 139 bytes, or +8b+ in hex
 * The sequence number is set to +FFFFFFFF+, again easy to identify((("", startref="alicesix")))
 
-When scriptSigs are serialized for transmission on the network, their inputs are encoded into a byte stream as shown in <<ScriptSig input serialization>>.
+When scriptSigs are serialized for transmission on the network, their inputs are encoded into a byte stream as shown in <<scriptsig_in_structure>>.
 
-[[tx_in_structure]]
+[[scriptsig_in_structure]]
 .ScriptSig input serialization
 [options="header"]
 |=======


### PR DESCRIPTION
The public key was lost in this chapter when dissecting the transaction in whole. For completeness, a table demonstrating a breakdown of the ScriptSig was necessary to cover this.