### PR TITLE
Added the a in "is a class"

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -186,7 +186,7 @@ passphrase::
     A passphrase is an optional string created by the user that serves as an additional security factor protecting the seed, even when the seed is compromised by a thief. It can also be used as a form of plausible deniability, where a chosen passphrase leads to a wallet with a small amount of funds used to distract an attacker from the “real” wallet that contains the majority of funds.
     
 payment channels::
-    A micropayment channel or payment channel is class of techniques designed to allow users to make multiple bitcoin transactions without committing all of the transactions to the bitcoin blockchain. In a typical payment channel, only two transactions are added to the block chain but an unlimited or nearly unlimited number of payments can be made between the participants.
+    A micropayment channel or payment channel is a class of techniques designed to allow users to make multiple bitcoin transactions without committing all of the transactions to the bitcoin blockchain. In a typical payment channel, only two transactions are added to the block chain but an unlimited or nearly unlimited number of payments can be made between the participants.
 
 pooled mining::
     Pooled mining is a mining approach where multiple generating clients contribute to the generation of a block, and then split the block reward according the contributed processing power.


### PR DESCRIPTION
I think there should be "[…] is a class […]" instead of "[…] is class […]". 
But I'm not a native english speaker, so please review it. 