### PR TITLE
ch07: fixed typo in P2SH scripts, missing 0 value at beginning

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -162,7 +162,7 @@ HASH160 54c557e07dde5bb6cb791c7a540e0a4796f5e97e EQUAL
 which, as you can see, is much shorter. Instead of "pay to this 5-key multisignature script," the P2SH equivalent transaction is "pay to a script with this hash." A customer making a payment to Mohammed's company need only include this much shorter locking script in his payment. When Mohammed and his partners want to spend this UTXO, they must present the original redeem script (the one whose hash locked the UTXO) and the signatures necessary to unlock it, like this:
 
 ----
-<Sig1> <Sig2> <2 PK1 PK2 PK3 PK4 PK5 5 CHECKMULTISIG>
+0 <Sig1> <Sig2> <2 PK1 PK2 PK3 PK4 PK5 5 CHECKMULTISIG>
 ----
 
 The two scripts are combined in two stages. First, the redeem script is checked against the locking script to make sure the hash matches:
@@ -173,7 +173,7 @@ The two scripts are combined in two stages. First, the redeem script is checked 
 If the redeem script hash matches, the unlocking script is executed on its own, to unlock the redeem script:
 
 ----
-<Sig1> <Sig2> 2 PK1 PK2 PK3 PK4 PK5 5 CHECKMULTISIG
+0 <Sig1> <Sig2> 2 PK1 PK2 PK3 PK4 PK5 5 CHECKMULTISIG
 ----
 
 Almost all the scripts described in this chapter can only be implemented as P2SH scripts. For example, a 2 of 5 standard multisignature locking script cannot be used directly in the locking script of an UTXO, as +IsStandard()+ would invalidate the transaction. To conform, a P2SH locking script can be used instead, as seen above. A transaction that then includes a P2SH unlocking script can be used to redeem this UTXO and will be valid so long as it does not contain more than 15 public keys. ((("", startref="mohamseven")))


### PR DESCRIPTION
This introduces the typo fix referred to in the issue [949](https://github.com/bitcoinbook/bitcoinbook/issues/949) where a 0 value is missing from CHECKMULTISIG redeem scripts.