### PR TITLE
Update ch04.asciidoc

### DIFF
--- a/ch04.asciidoc
+++ b/ch04.asciidoc
@@ -724,7 +724,7 @@ The example code must be compiled using a pass:[C++] compiler and linked against
 [source,bash]
 ----
 # Compile the code with g++
-$ g++ -o vanity-miner vanity-miner.cpp $(pkg-config --cflags --libs libbitcoin)
+$ g++ -o vanity-miner vanity-miner.cpp -std=c++11 $(pkg-config --cflags --libs libbitcoin)
 # Run the example
 $ ./vanity-miner
 Found vanity address! 1KiDzkG4MxmovZryZRj8tK81oQRhbZ46YT


### PR DESCRIPTION
Just like in code example 4, I have to include "-std=c++11" otherwise it won't compile, because of too many error messages.