### PR TITLE
Update ch09.asciidoc

### DIFF
--- a/ch09.asciidoc
+++ b/ch09.asciidoc
@@ -229,7 +229,7 @@ include::code/merkle.cpp[]
 [source,bash]
 ----
 # Compile the merkle.cpp code
-$ g++ -o merkle merkle.cpp $(pkg-config --cflags --libs libbitcoin)
+$ g++ -o merkle merkle.cpp -std=c++11 $(pkg-config --cflags --libs libbitcoin)
 # Run the merkle executable
 $ ./merkle
 Current merkle hash list:


### PR DESCRIPTION
I get error messages if I don't include "-std=c++11"