### PR TITLE
Update glossary.asciidoc

### DIFF
--- a/glossary.asciidoc
+++ b/glossary.asciidoc
@@ -27,13 +27,13 @@ Byzantine Generals Problem::
 candidate block::
 	A block that a miner is still trying to mine. It is not yet a valid block, because it does not contain a valid Proof-of-Work.
 
-coinbase (aka coinbase data)::
-	A special field used as the sole input for coinbase transactions. The coinbase data field allows claiming the block reward and provides up to 100 bytes for arbitrary data.
-	Not to be confused with coinbase transaction or coinbase reward.
-
 coinbase transaction::
 	The first transaction in a block. Always created by a miner, it includes a single coinbase.
 	Not to be confused with coinbase (coinbase data) or coinbase reward
+
+coinbase (aka coinbase data)::
+	A special field used as the sole input for coinbase transactions. The coinbase data field allows claiming the block reward and provides up to 100 bytes for arbitrary data.
+	Not to be confused with coinbase transaction or coinbase reward.
 
 cold storage::
 	Refers to keeping a reserve of bitcoin offline. Cold storage is achieved when bitcoin private keys are created and stored in a secure offline environment. Cold storage is important for anyone with bitcoin holdings. Online computers are vulnerable to hackers and should not be used to store a significant amount of bitcoin.


### PR DESCRIPTION
Defining 'coinbase transaction' before using it in the definition for 'coinbase (aka coinbase data)'.