### PR TITLE
Make AsciiDoc linguist-detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.asciidoc linguist-detectable


### PR DESCRIPTION
Hi, bitcoinops recently merged [a similar PR][0], for that reason
I thought of submitting this change for your consideration.
You might be (or not be) interested in these changes.

This is githubcentrism, but the file's commited referencing
linguist, which is GitHub (I think), so once you migrate
out of GitHub, you would eventually find out if you still need
this file or not.

---

Before this change, project gets detected as:

Python 33.8%
HTML 28.7%
C++ 16.7%
Go 11.1%
CSS 8.6%
JavaScript 1.1%

After this change, project gets detected as:

AsciiDoc 94.9%
Python 1.7%
HTML 1.5%
C++ 0.8%
Go 0.6%
CSS 0.4%
JavaScript 0.1%

This change was added for a cosmetic effect on GitHub.

---

Before this change | After this change
--- | ---
<img width="195" alt="Screen Shot 2021-09-29 at 23 37 59" src="https://user-images.githubusercontent.com/52637275/135352567-dcf457d1-a027-443d-b596-8641301b12fd.png"> | <img width="196" alt="Screen Shot 2021-09-29 at 23 38 04" src="https://user-images.githubusercontent.com/52637275/135352594-2aef9bb0-99af-481c-a057-a9f6a01bfc15.png">

---

Cheers!

[0]: https://github.com/bitcoinops/bitcoinops.github.io/pull/653