### PR TITLE
Remove claim that bitcoin value cannot be destroyed in a transaction

### DIFF
--- a/ch12.asciidoc
+++ b/ch12.asciidoc
@@ -25,7 +25,7 @@ Authorization:: Digital signatures, validated in a decentralized network, offer 
 
 Auditability:: All transactions are public and can be audited. All transactions and blocks can be linked back in an unbroken chain to the genesis block.
 
-Accounting:: In any transaction (except the coinbase transaction) the value of inputs is equal to the value of outputs plus fees. It is not possible to create or destroy bitcoin value in a transaction. The outputs cannot exceed the inputs.
+Accounting:: In any transaction (except the coinbase transaction) the value of inputs is equal to the value of outputs plus fees. It is not possible to create bitcoin value in a transaction. The outputs cannot exceed the inputs.
 
 Nonexpiration:: A valid transaction does not expire. If it is valid today, it will be valid in the near future, as long as the inputs remain unspent and the consensus rules do not change.
 


### PR DESCRIPTION
Remove "or destroy" from the sentence "It is not possible to create or destroy bitcoin value in a transaction."

I am not sure why it was worded this way. Bitcoin can easily be burned with an OP_RETURN transaction.