### PR TITLE
Adding one more reason to use P2SH instead of standard multisig

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -211,6 +211,7 @@ P2SH addresses hide all of the complexity, so that the person making a payment d
 * P2SH shifts the burden in data storage for the long script from the output (which additionally to being stored on the blockchain is in the UTXO set) to the input (only stored on the blockchain).
 * P2SH shifts the burden in data storage for the long script from the present time (payment) to a future time (when it is spent).
 * P2SH shifts the higher transaction fee costs of a long script from the sender to the recipient, who has to include the long redeem script to spend it.
+* P2SH hides from the sender the fact that the recipient is using a multisig address, or the M-of-N configuration used.
 
 ==== Redeem Script and Validation
 


### PR DESCRIPTION
Using P2SH also hides from the sender the fact that the recipient is using a multisig address, or the N-of-M configuration.