### PR TITLE
Replace output with input in ch07 

### DIFF
--- a/ch07.asciidoc
+++ b/ch07.asciidoc
@@ -646,7 +646,7 @@ In cryptography, the term "witness" is used to describe a solution to a cryptogr
 
 In the context of bitcoin, a digital signature is _one type of witness_, but a witness is more broadly any solution that can satisfy the conditions imposed on an UTXO and unlock that UTXO for spending. The term “witness” is a more general term for an “unlocking script” or “scriptSig.”
 
-Before segwit’s introduction, every input in a transaction was followed by the witness data that unlocked it. The witness data was embedded in the transaction as part of each input. The term _segregated witness_, or _segwit_ for short, simply means separating the signature or unlocking script of a specific output. Think "separate scriptSig," or “separate signature” in the simplest form.
+Before segwit’s introduction, every input in a transaction was followed by the witness data that unlocked it. The witness data was embedded in the transaction as part of each input. The term _segregated witness_, or _segwit_ for short, simply means separating the signature or unlocking script of a specific input. Think "separate scriptSig," or “separate signature” in the simplest form.
 
 Segregated Witness therefore is an architectural change to bitcoin that aims to move the witness data from the +scriptSig+ (unlocking script) field of a transaction into a separate _witness_ data structure that accompanies a transaction. Clients may request transaction data with or without the accompanying witness data.
 


### PR DESCRIPTION
Since the unlocking script is part of the input - shouldn't this read `input` instead of `output` ?