### PR TITLE
Off-by-one error on block count line 120

### DIFF
--- a/ch09.asciidoc
+++ b/ch09.asciidoc
@@ -117,7 +117,7 @@ The genesis block contains a hidden message within it. The coinbase transaction 
 
 ((("blocks", "linking blocks in the blockchain")))((("blockchain (the)", "linking blocks in the blockchain")))Bitcoin full nodes maintain a local copy of the blockchain, starting at the genesis block. The local copy of the blockchain is constantly updated as new blocks are found and used to extend the chain. As a node receives incoming blocks from the network, it will validate these blocks and then link them to the existing blockchain. To establish a link, a node will examine the incoming block header and look for the "previous block hash."
 
-Let's assume, for example, that a node has 277,314 blocks in the local copy of the blockchain. The last block the node knows about is block 277,314, with a block header hash of:
+Let's assume, for example, that a node has 277,315 blocks in the local copy of the blockchain. The last block the node knows about is block 277,314, with a block header hash of:
 
 ----
 00000000000000027e7ba6fe7bad39faf3b5a83daed765f05f7d1b71a1632249


### PR DESCRIPTION
Least invasive fix is to increment the count on line 120 as opposed to referencing a different block altogether.