### PR TITLE
fixed curl so it can be copied and executed in terminal without error

### DIFF
--- a/ch02.asciidoc
+++ b/ch02.asciidoc
@@ -155,7 +155,7 @@ If the wallet application does not maintain a copy of unspent transaction output
 ====
 [source,bash]
 ----
-$ curl https://blockchain.info/unspent?active=1Cdid9KFAaatwczBwBttQcwXYCpvK8h7FK
+$ curl 'https://blockchain.info/unspent?active=1Cdid9KFAaatwczBwBttQcwXYCpvK8h7FK'
 ----
 ====
 


### PR DESCRIPTION
The question mark is not escaped and it is causing the following error when executed. The adding of single quotes solves the problem. 

`zsh: no matches found: https://blockchain.info/unspent?active=1Cdid9KFAaatwczBwBttQcwXYCpvK8h7FK`