### PR TITLE
Fix inconsistent notations

### DIFF
--- a/ch05.asciidoc
+++ b/ch05.asciidoc
@@ -316,7 +316,7 @@ The master private key (m) then generates a corresponding master public key (M) 
 
 The chain code (c) is used to introduce entropy in the function that creates child keys from parent keys, as we will see in the next section.
 
-===== Private child key derivation
+===== Child private key derivation
 
 ((("child key derivation (CKD)")))((("public and private keys", "child key derivation (CKD)")))HD wallets use a _child key derivation_ (CKD) function to derive child keys from parent keys.
 
@@ -328,7 +328,7 @@ The child key derivation functions are based on a one-way hash function that com
 
 The chain code is used to introduce deterministic random data to the process, so that knowing the index and a child key is not sufficient to derive other child keys. Knowing a child key does not make it possible to find its siblings, unless you also have the chain code. The initial chain code seed (at the root of the tree) is made from the seed, while subsequent child chain codes are derived from each parent chain code.
 
-These three items (parent key, chain code, and index) are combined and hashed to generate children keys, as follows.
+These three items (parent key, chain code, and index) are combined and hashed to generate child keys, as follows.
 
 The parent public key, chain code, and the index number are combined and hashed with the HMAC-SHA512 algorithm to produce a 512-bit hash. This 512-bit hash is split into two 256-bit halves. The right-half 256 bits of the hash output become the chain code for the child. The left-half 256 bits of the hash are added to the parent key to produce the child private key. In <<CKDpriv>>, we see this illustrated with the index set to 0 to produce the "zero" (first by index) child of the parent.
 
@@ -379,9 +379,9 @@ xpub67xpozcx8pe95XVuZLHXZeG6XWXHpGq6Qv5cmNfi7cS5mtjJ2tgypeQbBs2UAR6KECeeMVKZBPLr
 ----
 
 [[public__child_key_derivation]]
-===== Public child key derivation
+===== Child public key derivation
 
-((("public and private keys", "public child key derivation")))As mentioned  previously, a very useful characteristic of HD wallets is the ability to derive public child keys from public parent keys, _without_ having the private keys. This gives us two ways to derive a child public key: either from the child private key, or directly from the parent public key.
+((("public and private keys", "public child key derivation")))As mentioned previously, a very useful characteristic of HD wallets is the ability to derive child public keys from parent public keys, _without_ having the private keys. This gives us two ways to derive a child public key: either from the child private key, or directly from the parent public key.
 
 An extended public key can be used, therefore, to derive all of the _public_ keys (and only the public keys) in that branch of the HD wallet structure.
 


### PR DESCRIPTION
Notice that parent private key, parent public key, child private key, child public key, private parent key, public parent key, private child key, and public child key are all used in this chapter.

Within public-key cryptosystems, there are private key and public key pairs. Thus, here for parent nodes, there are parent key pairs (incl. parent private key and parent public key), and for child nodes, there are child key pairs (incl. child private key and child public key). Those notations, such as private/public parent/child key, are illogical since it ignores the fact that private/public keys are associated with parent nodes and child nodes.