### PR TITLE
ch06(Transaction serialization—outputs): update tx output hex representation

### DIFF
--- a/ch06.asciidoc
+++ b/ch06.asciidoc
@@ -167,7 +167,7 @@ Here are some hints:
 
 * There are two outputs in the highlighted section, each serialized as shown in <<tx_out_structure>>.
 * The value of 0.015 bitcoin is 1,500,000 satoshis. That's +16 e3 60+ in hexadecimal.
-* In the serialized transaction, the value +16 e3 60+ is encoded in little-endian (least-significant-byte-first) byte order, so it looks like +60 e3 16+.
+* In the serialized transaction, the value +16 e3 60+ is encoded in little-endian (least-significant-byte-first) byte order, so it looks like +60 e3 16 00 00 00 00 00+.
 * The +scriptPubKey+ length is 25 bytes, which is +19+ in hexadecimal.
 
 [[tx_inputs]]


### PR DESCRIPTION
The specification of the transaction output states that amount is represented by 8 bytes field.

I think that it might be helpful for people who is not familiar with the hex format to explicitly state that the output's satoshi amount in the TX hex string sample is represented by `60e3160000000000` instead of just `60e316`