### PR TITLE
Ch03: change prune units from megabytes to mebibytes

### DIFF
--- a/ch03.asciidoc
+++ b/ch03.asciidoc
@@ -296,7 +296,7 @@ conf:: An alternative location for the configuration file. This only makes sense
 
 datadir:: Select the directory and filesystem in which to put all the blockchain data. By default this is the _.bitcoin_ subdirectory of your home directory. Make sure this filesystem has several gigabytes of free space.
 
-prune:: Reduce the disk space requirements to this many megabytes, by deleting old blocks. Use this on a resource-constrained node that can't fit the full blockchain.
+prune:: Reduce the disk space requirements to this many mebibytes, by deleting old blocks. Use this on a resource-constrained node that can't fit the full blockchain.
 
 txindex:: Maintain an index of all transactions. This means a complete copy of the blockchain that allows you to programmatically retrieve any transaction by ID.
 


### PR DESCRIPTION
The units for the `prune` configuration option should be mebibytes (MiB) instead of megabytes. This can be seen in the Bitcoin Core source code at the following location: https://github.com/nmfretz/bitcoin/blob/9dce30194bc07463d634072251a8bf83e1b10ff9/src/init.cpp#L436-L438