### PR TITLE
Update ch05.asciidoc

### DIFF
--- a/ch05.asciidoc
+++ b/ch05.asciidoc
@@ -364,7 +364,7 @@ Think of an extended key as the root of a branch in the tree structure of the HD
 An extended key consists of a private or public key and chain code. An extended key can create children, generating its own branch in the tree structure. Sharing an extended key gives access to the entire branch.
 ====
 
-Extended keys are encoded using Base58Check, to easily export and import between different BIP-32&#x2013;compatible wallets. The Base58Check coding for extended keys uses a special version number that results in the prefix "xprv" and "xpub" when encoded in Base58 characters to make them easily recognizable. Because the extended key is 512 or 513 bits, it is also much longer than other Base58Check-encoded strings we have seen previously.
+Extended keys are encoded using Base58Check, to easily export and import between different BIP-32&#x2013;compatible wallets. The Base58Check coding for extended keys uses a special version number that results in the prefix "xprv" and "xpub" when encoded in Base58 characters to make them easily recognizable. Because the extended key is 512 bits [256 bits(private key) + 256 bits(chain code)] or 520 bits [264 bits(public key) + 256 bits(chain code)], it is also much longer than other Base58Check-encoded strings we have seen previously.
 
 Here's an example of an extended _private_ key, encoded in Base58Check:
 


### PR DESCRIPTION
In the section on extended keys, the line "Because the extended key is 512 or 513 bits, it is also much longer than other Base58Check-encoded strings we have seen previously" mentions that the extended key is 513 bits. But how is it 513 bits? Shouldn't it instead be as follows: Because the extended key is 512 bits [256 bits(private key) + 256 bits(chain code)] or 520 bits [264 bits(public key) + 256 bits(chain code)], it is also much longer than other Base58Check-encoded strings we have seen previously.