### PR TITLE
Textpassage removed in Chapter 2

### DIFF
--- a/ch02.asciidoc
+++ b/ch02.asciidoc
@@ -80,16 +80,6 @@ In the following sections, we will examine this transaction in more detail. We'l
 ((("fractional values")))((("milli-bitcoin")))((("satoshis")))The Bitcoin network can transact in fractional values, e.g., from millibitcoin (1/1000th of a bitcoin) down to 1/100,000,000th of a bitcoin, which is known as a satoshi.  Throughout this book, we’ll use the term “bitcoin” to refer to any quantity of bitcoin currency, from the smallest unit (1 satoshi) to the total number (21,000,000) of all bitcoin that will ever be mined.
 ====
 
-You can examine Alice's transaction to Bob's Cafe on the blockchain using a block explorer site (<<view_alice_transaction>>):
-
-[[view_alice_transaction]]
-.View Alice's transaction on https://www.blockchain.com/btc/tx/0627052b6f28912f2703066a912ea577f2ce4da4caa5a5fbd8a57286c345c2f2[blockchain.com]
-====
-----
-https://www.blockchain.com/btc/tx/0627052b6f28912f2703066a912ea577f2ce4da4caa5a5fbd8a57286c345c2f2
-----
-====
-
 === Bitcoin Transactions
 
 ((("transactions", "defined")))In simple terms, a transaction tells the network that the owner of some bitcoin value has authorized the transfer of that value to another owner. The new owner can now spend the bitcoin by creating another transaction that authorizes the transfer to another owner, and so on, in a chain of ownership.


### PR DESCRIPTION
Given TransactionID of the example is not availble at blockchain.com: https://blockexplorer.com/txs/0627052b6f28912f2703066a912ea577f2ce4da4caa5a5fbd8a57286c345c2f2