### PR TITLE
Omit 0 from private key range

### DIFF
--- a/ch04_keys.adoc
+++ b/ch04_keys.adoc
@@ -121,7 +121,7 @@ or repeatable. Bitcoin software uses cryptographically secure random
 number generators to produce 256 bits of entropy.
 
 [role="less_space pagebreak-before"]
-More precisely, the private key can be any number between 0 and _n_ -
+More precisely, the private key can be any number between 1 and _n_ -
 1 inclusive, where _n_ is a constant (_n_ = 1.1578 × 10^77^, slightly less
 than 2^256^) defined as the order of the elliptic curve used in Bitcoin
 (see <<elliptic_curve>>). To create such a key, we randomly pick a


### PR DESCRIPTION
Changed to remove 0 from the private key range, as 0 is invalid.