### PR TITLE
Fix error in HTLC example of ch14

### DIFF
--- a/ch14_applications.adoc
+++ b/ch14_applications.adoc
@@ -953,7 +953,6 @@ The script implementing an HTLC might look like this:
 IF
     # Payment if you have the secret R
     HASH160 <H> EQUALVERIFY
-    <Receiver Public Key> CHECKSIG
 ELSE
     # Refund after timeout.
     <lock time> CHECKLOCKTIMEVERIFY DROP


### PR DESCRIPTION
The example includes a pubKey and checksig OP-code, but the text suggests there should only be the check for the preimage. Therefore, I removed the pubKey and checksig from the example.