### PR TITLE
small fix for the description of how output scripts in old nodes can spent segwit output script (anyone-can-spend script)

### DIFF
--- a/ch06_transactions.adoc
+++ b/ch06_transactions.adoc
@@ -952,7 +952,7 @@ program_.  It's also possible to wrap the segwit template in a P2SH
 commitment, but we won't deal with that in this chapter.
 
 From the perspective of old nodes, these output script templates can be
-spent with an empty input script.  From the perspective of a new node that
+spent with an input script containing just OP_TRUE. From the perspective of a new node that
 is aware of the new segwit rules, any payment to a segwit output script
 template must only be spent with an empty input script.  Notice the
 difference here: old nodes _allow_ an empty input script; new nodes

--- a/meta/github_contrib.adoc
+++ b/meta/github_contrib.adoc
@@ -139,6 +139,7 @@
 <li>Parzival (Parz-val)</li>
 <li><p class="left-align">Paul Desmond Parker <span class="keep-together">(sunwukonga)</span></p></li>
 <li>Philipp Gille (philippgille)</li>
+<li>Rafael Jan (rafraph)</li>
 <li>ratijas</li>
 <li>rating89us</li>
 <li>Raul Siles (raulsiles)</li>


### PR DESCRIPTION
small fix for the description of how output scripts in old nodes can spent segwit output script (anyone-can-spend script). The way is by using input script containing OP_TRUE command, as described in the first mention of "anyone-can-spend" in this chapter, and not by using empty input script