### PR TITLE
Update Bitcoin QR Code URI in book to match the actual URI

### DIFF
--- a/ch02_overview.adoc
+++ b/ch02_overview.adoc
@@ -104,16 +104,16 @@ application to see what Alice would see:
 [[invoice-URI]]
 .The invoice QR code encodes the following URI, defined in BIP21:
 ----
-bitcoin:bc1qk2g6u8p4qm2s2lh3gts5cpt2mrv5skcuu7u3e4?amount=0.01577764&
-label=Bob%27s%20Store&
-message=Purchase%20at%20Bob%27s%20Store
+bitcoin:1GdK9UzpHBzqzX2A9JFP3Di4weBwqgmoQA?amount=0.015&
+label=Bob%27s%20Cafe&
+message=Purchase%20at%20Bob%27s%20Cafe
 
 Components of the URI
 
-A Bitcoin address: "bc1qk2g6u8p4qm2s2lh3gts5cpt2mrv5skcuu7u3e4"
-The payment amount: "0.01577764"
-A label for the recipient address: "Bob's Store"
-A description for the payment: "Purchase at Bob's Store"
+A Bitcoin address: "1GdK9UzpHBzqzX2A9JFP3Di4weBwqgmoQA"
+The payment amount: "0.015"
+A label for the recipient address: "Bob's Cafe"
+A description for the payment: "Purchase at Bob's Cafe"
 ----
 
 [TIP]

--- a/meta/github_contrib.adoc
+++ b/meta/github_contrib.adoc
@@ -152,6 +152,7 @@
 <li>Sam Ritchie (sritchie)</li>
 <li>Samir Sadek (netsamir)</li>
 <li>Sandro Conforto (sandroconforto)</li>
+<li>Sanghun Kang (sanghunka)</li>
 <li>Sanjay Sanathanan (sanjays95)</li>
 <li>Sebastian Falbesoner (theStack)</li>
 <li>Sergei Tikhomirov (s-tikhomirov)</li>


### PR DESCRIPTION
When scanning [the QR code(mbc3_0201.png)](https://github.com/bitcoinbook/bitcoinbook/blob/6d1c26e1640ae32b28389d5ae4caf1214c2be7db/images/mbc3_0201.png) in the book, the obtained URI does not match the actual URI. This is a pull request to update the content in the book to reflect the actual URI.

