### PR TITLE
Correct the description of lock time

### DIFF
--- a/ch06_transactions.adoc
+++ b/ch06_transactions.adoc
@@ -1050,9 +1050,9 @@ transaction in a block unless it satisfies one of the following rules:
 - The transaction indicates that it wants to restrict which blocks it
   can be included in by setting its lock time to a value less than
   500,000,000.  In this case, the transaction can only be included in a
-  block that has a height equal to the lock time or higher.  For
+  block that has a height greater than the lock time.  For
   example, a transaction with a lock time of 123,456 can be included in
-  block 123,456 or any later block.
+  block 123,457 or any later block.
 
 - The transaction indicates that it wants to restrict when it can be
   included in the blockchain by setting its lock time to a value of


### PR DESCRIPTION
The lock time defines the last block height that cannot include the transaction.

See: https://github.com/bitcoin/bitcoin/blob/080a47cb8a8db27328bbdf57aa80cc4b4127a370/src/consensus/tx_verify.cpp#L21