### PR TITLE
typo: TH/s should be TH

### DIFF
--- a/ch12_mining.adoc
+++ b/ch12_mining.adoc
@@ -1297,7 +1297,7 @@ modify the timestamp.
 Another solution widely used today is to use up to 16 bits of the block
 header versionbits field for mining, as described in BIP320.  If each
 piece of mining equipment has its own coinbase transaction, this allows
-an individual piece of mining equipment to perform up to 281 TH/s by
+an individual piece of mining equipment to perform up to 281 TH by
 only making changes to the block header.  This keeps mining equipment
 and protocols simpler than incrementing the extra nonce in the coinbase
 transaction every 4 billion hashes, which requires recalculating the


### PR DESCRIPTION
The unit of measurement is TH, not TH/s.

The total number of bits you can use for the nonce is: 16 bits from versionbits, plus 32 bits from the standard nonce field, for a total of 281 TH. This number does not measure a rate, but the total space the hashing process can browse with that number of nonce bits.

2^(16+32) == 281 TH