### PR TITLE
Change 'longer' chain with 'more work' chain

### DIFF
--- a/ch11_blockchain.adoc
+++ b/ch11_blockchain.adoc
@@ -61,7 +61,7 @@ change. After 100 blocks back there is so much stability that
 the coinbase transaction--the transaction containing the reward in
 bitcoin for creating a new block--can be spent.
 While the
-protocol always allows a chain to be undone by a longer chain and while
+protocol always allows a chain to be undone by another chain with more work and while
 the possibility of any block being reversed always exists, the
 probability of such an event decreases as time passes until it ((("blockchain", "explained", startref="blockchain-explain")))becomes
 infinitesimal.


### PR DESCRIPTION
The longer chain does not always have more proof of work and thus is not always the best chain. Rather, the best chain is the chain with more proof of work