### PR TITLE
fix(ch6): replace "upgraded" with "introduced" for OP_CHECKSEQUENCEVERIFY

### DIFF
--- a/ch06_transactions.adoc
+++ b/ch06_transactions.adoc
@@ -100,7 +100,7 @@ change to Bitcoin's consensus rules.  BIP68 places additional
 constraints on the sequence field, but those constraints only apply to
 transactions with version 2 or higher.  Version 1 transactions are
 unaffected.  BIP112, which was part of the same soft fork as BIP68,
-upgraded an opcode (++OP_CHECKSEQUENCEVERIFY++), which will now fail if it is
+introduced an opcode (++OP_CHECKSEQUENCEVERIFY++), which will now fail if it is
 evaluated as part of a transaction with a version less than 2.  Beyond
 those two changes, version 2 transactions are identical to version 1
 transactions.

--- a/ch06_transactions.adoc
+++ b/ch06_transactions.adoc
@@ -100,7 +100,7 @@ change to Bitcoin's consensus rules.  BIP68 places additional
 constraints on the sequence field, but those constraints only apply to
 transactions with version 2 or higher.  Version 1 transactions are
 unaffected.  BIP112, which was part of the same soft fork as BIP68,
-introduced an opcode (++OP_CHECKSEQUENCEVERIFY++), which will now fail if it is
+repurposed OP_NOP3 to introduce a new opcode (++OP_CHECKSEQUENCEVERIFY++), which will now fail if it is
 evaluated as part of a transaction with a version less than 2.  Beyond
 those two changes, version 2 transactions are identical to version 1
 transactions.


### PR DESCRIPTION
The statement that "BIP112 upgraded the OP_CHECKSEQUENCEVERIFY opcode" is not entirely accurate because OP_CHECKSEQUENCEVERIFY (CSV) was not an upgrade of an existing opcode but a new opcode introduced by BIP112.

A more appropriate statement would be "BIP112, which was part of the same soft fork as BIP68, introduced a new opcode (OP_CHECKSEQUENCEVERIFY)"