### PR TITLE
Two small fixes of texts for ch07

### DIFF
--- a/ch06_transactions.adoc
+++ b/ch06_transactions.adoc
@@ -952,7 +952,7 @@ program_.  It's also possible to wrap the segwit template in a P2SH
 commitment, but we won't deal with that in this chapter.
 
 From the perspective of old nodes, these output script templates can be
-spent with an empty input script.  From the perspective of a new node that
+spent with an input script containing just OP_TRUE. From the perspective of a new node that
 is aware of the new segwit rules, any payment to a segwit output script
 template must only be spent with an empty input script.  Notice the
 difference here: old nodes _allow_ an empty input script; new nodes

--- a/ch07_authorization-authentication.adoc
+++ b/ch07_authorization-authentication.adoc
@@ -1670,7 +1670,7 @@ exceeds the number of conditions that all the computers in the world
 could create.
 
 It's commonly the case that not every authorization condition is equally
-as likely to be used.  In the our example case, we expect Mohammed and
+as likely to be used.  In our example case, we expect Mohammed and
 his partners to spend their money frequently; the time delayed
 conditions only exist in case something goes wrong.  We can restructure
 our tree with this knowledge as shown in <<diagram_mast3>>.
@@ -1698,8 +1698,8 @@ Except for increasing the complexity of Bitcoin slightly, there are no
 significant downsides of MAST for Bitcoin and there were two solid
 proposals for it, BIP114 and BIP116, before an improved approach was
 discovered, which we'll see in <<taproot>>.
-
-.MAST Versus MAST
+[[mast_versus_mast]]
+=== MAST Versus MAST
 ****
 The earliest((("abstract syntax trees (AST)")))((("AST (abstract syntax trees)"))) idea for what we now know as _MAST_ in Bitcoin was
 _merklized abstract syntax trees_.  In an abstract syntax tree (AST),


### PR DESCRIPTION
1. Remove unnecessary "the"
2. Make "MAST Versus MAST" a header