### PR TITLE
Clarify text in Hardened child key derivation

### DIFF
--- a/ch05_wallets.adoc
+++ b/ch05_wallets.adoc
@@ -1368,10 +1368,7 @@ of public keys from an xpub is very useful, but it comes with a
 potential risk. Access to an xpub does not give access to child private
 keys. However, because the xpub contains the chain code, if a child
 private key is known, or somehow leaked, it can be used with the chain
-code to derive all the other child private keys. A single leaked child
-private key, together with a parent chain code, reveals all the private
-keys of all the children. Worse, the child private key together with a
-parent chain code can be used to deduce the parent private key.
+code to derive all the other child private keys. A single leaked child private key, together with a parent chain code, can be used to deduce the parent private key. As a result, all of the child private keys of the parent are compromised.
 
 To counter this risk, HD wallets provide an alternative derivation function
 called _hardened derivation_, which breaks the relationship between

--- a/meta/github_contrib.adoc
+++ b/meta/github_contrib.adoc
@@ -168,6 +168,7 @@
 <li>Thiago Arrais (thiagoarrais)</li>
 <li>Thomas Kerin (afk11)</li>
 <li>Tochi Obudulu (tochicool)</li>
+<li>Tony Lu (tlulu)</li>
 <li>Tosin (tkuye)</li>
 <li>Vasil Dimov (vasild)</li>
 <li>venzen</li>


### PR DESCRIPTION
## What
The original text "A single leaked child private key, together with a parent chain code, reveals all the private keys of all the children." implies that a child private key, parent chain code and parent public key can derive the other child private keys of the parent. However it can only do that if the parent private key is deduced. This PR clarifies the text to make it more accurate.
