### PR TITLE
Mathematically, Elliptic Curve is not a function.

### DIFF
--- a/ch04_keys.adoc
+++ b/ch04_keys.adoc
@@ -777,7 +777,7 @@ results in smaller transactions, allowing more payments to be made in the same
 block.
 
 As we saw in the section <<public_key_derivation>>, a public key is a point [.keep-together]#(x, y)# on an
-elliptic curve. Because the curve expresses a mathematical function, a
+elliptic curve. Because the curve expresses a mathematical mapping, a
 point on the curve represents a solution to the equation and, therefore,
 if we know the _x_ coordinate, we can calculate the _y_ coordinate by
 solving the equation [.keep-together]#y^2^ mod p = (x^3^ + 7) mod p.# That allows us to

--- a/ch04_keys.adoc
+++ b/ch04_keys.adoc
@@ -178,7 +178,7 @@ image::images/mbc3_0402.png["ecc-curve"]
 Bitcoin uses a specific elliptic curve and set of mathematical
 constants, as defined in a standard called +secp256k1+, established by
 the National Institute of Standards and Technology (NIST). The
-+secp256k1+ curve is defined by the following function, which produces
++secp256k1+ curve is defined by the following equation, which produces
 an elliptic curve:
 
 [latexmath]

--- a/meta/github_contrib.adoc
+++ b/meta/github_contrib.adoc
@@ -189,6 +189,7 @@
 <li>yurigeorgiev4</li>
 <li>Zheng Jia (zhengjia)</li>
 <li>Zhou Liang (zhouguoguo)</li>
+<li>Suyang Liu (LiuYusuf)</li>
 </ul>
 ++++
 


### PR DESCRIPTION
An **elliptic curve** is not a function because it fails the vertical line test: if a vertical line intersects the curve more than once on an xy-plane, then the curve has more than one values of y for one value of x, and therefore it doesn't represent a function. Therefore, the two places where an elliptic curve is referred to as a function should be corrected. 

It should be acceptable to say **Elliptic curve multiplication** is function. So there is no need to edit such expressions.
