### PR TITLE
removed grammatical redundancy of "are" ch13

### DIFF
--- a/ch13_security.adoc
+++ b/ch13_security.adoc
@@ -1,8 +1,8 @@
 [[ch11]]
 == Bitcoin Security
 
-Securing your bitcoins is challenging because bitcoins are
-are not like a balance in a bank account. Your bitcoins are very
+Securing your bitcoins is challenging because bitcoins are 
+not like a balance in a bank account. Your bitcoins are very
 much like digital cash or gold. You've probably heard the expression,
 "Possession is nine-tenths of the law." Well, in Bitcoin, possession is
 ten-tenths of the law. Possession of the keys to spend certain bitcoins is

--- a/meta/github_contrib.adoc
+++ b/meta/github_contrib.adoc
@@ -54,6 +54,7 @@
 <li>Evlix</li>
 <li>fabienhinault</li>
 <li>Fan (whiteath)</li>
+<li>Abisuwa Oluwadunsin (Dunsin-cyber)</li>
 <li>Felix Filozov (ffilozov)</li>
 <li>Francis Ballares (fballares)</li>
 <li>François Wirion (wirion)</li>


### PR DESCRIPTION
### I removed grammatical redundancy of "are" ch13's first sentence. 
It was previously 

> _Securing your bitcoins is challenging because bitcoins **are are** not like a balance in a bank account._

 but now corrected to 

> _Securing your bitcoins is challenging because bitcoins **are** not like a balance in a bank account._