### PR TITLE
Ch09 - The text "none of its descendants can be included in the same blockchain" is misleading

### DIFF
--- a/ch09_fees.adoc
+++ b/ch09_fees.adoc
@@ -474,7 +474,7 @@ transaction relationships.  Whenever the output of a transaction is
 spent, that transaction's identifier (txid) is referenced by the child
 transaction.  However, when a transaction is replaced, the replacement
 has a different txid.  If that replacement transaction gets confirmed,
-none of its descendants can be included in the same blockchain.  It's
+all of its descendants will be invalid.  It's
 possible to re-create and re-sign the descendant transactions, but that's
 not guaranteed to happen.  This has related but divergent implications
 for RBF and CPFP:

--- a/meta/github_contrib.adoc
+++ b/meta/github_contrib.adoc
@@ -139,6 +139,7 @@
 <li>Parzival (Parz-val)</li>
 <li><p class="left-align">Paul Desmond Parker <span class="keep-together">(sunwukonga)</span></p></li>
 <li>Philipp Gille (philippgille)</li>
+<li>Rafael Jan (rafraph)</li>
 <li>ratijas</li>
 <li>rating89us</li>
 <li>Raul Siles (raulsiles)</li>


### PR DESCRIPTION
The text "none of its descendants can be included in the same blockchain" is misleading. Because it actually can't be included in any blockchain. I think it should be "all of its descendants will be invalid", because now the txid that descendants are using is invalid and can't be used in any blockchain.