### PR TITLE
Fix BIP49 derivation path to use `m/49'/0'/0'` for mainnet

### DIFF
--- a/ch05_wallets.adoc
+++ b/ch05_wallets.adoc
@@ -585,7 +585,7 @@ paths_. Several popular implicit paths defined by BIPs are shown in <<bip_implic
 <tr>
 <td><p>BIP49</p></td>
 <td><p>Nested P2WPKH</p></td>
-<td><p><code>m/49'/1'/0'</code></p></td>
+<td><p><code>m/49'/0'/0'</code></p></td>
 </tr>
 <tr>
 <td><p>BIP84</p></td>


### PR DESCRIPTION
According to https://github.com/satoshilabs/slips/blob/master/slip-0044.md, `coin_type` should be 0 for mainnet & 1 for testnet.