### PR TITLE
fix(ch06): Fix typo in attacker bandwidth

### DIFF
--- a/ch06_transactions.adoc
+++ b/ch06_transactions.adoc
@@ -485,7 +485,7 @@ transaction with a different version an unlimited number of
 times.  Each replacement would consume the bandwidth of all the relaying full nodes
 on the network.  For example, as of this writing, there are about 50,000
 relaying full nodes; an attacker creating 1,000 replacement transactions
-per minute at 200 bytes each would use about 20 KB of their
+per minute at 200 bytes each would use about 200 KB of their
 personal bandwidth but about 10 GB of full node network bandwidth
 every minute.  Except for the cost of their 20 KB/minute bandwidth and
 the occasional fee when a transaction got confirmed, the attacker wouldn't

--- a/meta/github_contrib.adoc
+++ b/meta/github_contrib.adoc
@@ -112,6 +112,7 @@
 <li>Martin Harrigan (harrigan)</li>
 <li>Martin Vseticka (MartyIX)</li>
 <li>Marzig (marzig76)</li>
+<li>Matevž Jekovec (matevz)</li>
 <li>Matt McGivney (mattmcgiv)</li>
 <li>Matthijs Roelink (Matthiti)</li>
 <li>Maximilian Reichel (phramz)</li>


### PR DESCRIPTION
20 B * 10,000 equals 200 KB, not 20 KB. The rest of the sentence seems fine.