### PR TITLE
Update ch10_network.adoc

### DIFF
--- a/ch10_network.adoc
+++ b/ch10_network.adoc
@@ -1021,7 +1021,7 @@ block.  In other words, the output script being spent.
 
 This had several advantages.  First, it meant that wallets didn't need
 to track outpoints; they could instead just scan for the
-output scripts to which they expected to receive money. Second, any time a
+output scripts in which they expected to send money. Second, any time a
 later transaction in a block spends the output of an earlier
 transaction in the same block, they'll both reference the same
 output script.  More than one reference to the same output script is

--- a/ch11_blockchain.adoc
+++ b/ch11_blockchain.adoc
@@ -527,7 +527,7 @@ The largest possible block can hold almost 16,000 transactions in 4,000,000
 bytes, but proving any particular one of those 16,000 transactions
 is a part of that block only requires a copy of the transaction, a copy
 of the 80-byte block header, and 448 bytes for the merkle proof.  That
-makes the largest possible proof almost 10,000 times smaller than the
+makes the largest possible proof almost 5,000 times smaller than the
 largest possible Bitcoin block.
 
 === Merkle Trees and Lightweight Clients


### PR DESCRIPTION
This section talked about that a wallet can scan scripts in outpoints which means in outputs that referenced by txid in inputs. 
Since the source is the input, it means these places are that the wallet send money and not receive money. 
The wallet will find the received money in the outputs not in outpoints