### PR TITLE
`max_money.py` fixes and improvements

### DIFF
--- a/ch12_mining.adoc
+++ b/ch12_mining.adoc
@@ -152,7 +152,7 @@ include::code/max_money.py[]
 [source,bash]
 ----
 $ python max_money.py
-Total BTC to ever be created: 2099999997690000 Satoshis
+Total BTC to ever be created: 2099999997690000 satoshis
 ----
 ====
 

--- a/code/max_money.py
+++ b/code/max_money.py
@@ -1,17 +1,20 @@
 # Original block reward for miners was 50 BTC
 start_block_reward = 50
-# 210000 is around every 4 years with a 10 minute block interval
-reward_interval = 210000
+# 210000 blocks is roughly every 4 years at 10 minutes per block
+reward_interval = 210_000
 
 
 def max_money():
-    # 50 BTC = 50 0000 0000 Satoshis
-    current_reward = 50 * 10**8
+    # 1 BTC = 100_000_000 satoshis
+    current_reward = start_block_reward * 100_000_000
     total = 0
     while current_reward > 0:
         total += reward_interval * current_reward
-        current_reward /= 2
+
+        # Halve the mining reward using integer division.
+        # This discards any fractional satoshis, matching the Bitcoin protocol's halving calculation.
+        current_reward //= 2
     return total
 
-
-print("Total BTC to ever be created:", max_money(), "Satoshis")
+total_satoshis = max_money()
+print("Total BTC to ever be created:", max_money(), "satoshis")

--- a/code/max_money.py
+++ b/code/max_money.py
@@ -1,8 +1,7 @@
 # Original block reward for miners was 50 BTC
 start_block_reward = 50
-# 210000 blocks is roughly every 4 years at 10 minutes per block
+# 210_000 blocks, approximately 4 years at 10 minutes per block
 reward_interval = 210_000
-
 
 def max_money():
     # 1 BTC = 100_000_000 satoshis
@@ -10,11 +9,9 @@ def max_money():
     total = 0
     while current_reward > 0:
         total += reward_interval * current_reward
-
         # Halve the mining reward using integer division.
         # This discards any fractional satoshis, matching the Bitcoin protocol's halving calculation.
         current_reward //= 2
     return total
 
-total_satoshis = max_money()
 print("Total BTC to ever be created:", max_money(), "satoshis")

--- a/meta/github_contrib.adoc
+++ b/meta/github_contrib.adoc
@@ -26,6 +26,7 @@
 <li>Cihat Imamoglu (cihati)</li>
 <li>Cody Scott (Siecje)</li>
 <li>coinradar</li>
+<li>Colin Green (colgreen)</li>
 <li>Cragin Godley (cgodley)</li>
 <li>Craig Dodd (cdodd)</li>
 <li>dallyshalla</li>


### PR DESCRIPTION
* Fix: Use python floor/integer division operator (`//`) to give correct result of` 2_099_999_997_690_000` satoshis instead of `2_100_000_000_000`. This is due to a behaviour change in python; `/` in python 3.x always performs floating point division, even for integer operands.
* Used the `start_block_reward` variable (was declared but not used).
* Used an underscore "thousands separator" for number constants. This is hopefully more readable, whilst avoiding use of any locale/region specific separator, such as a comma or dot.
* Changed "Satoshis" to "satoshis" in final output, in line with the casing using elsewhere in the book.
* Changed comment `# 210000 is around every 4 years with a 10 minute block interval` to `# 210_000 blocks, approximately 4 years at 10 minutes per block` (improved clarify/readability?).