### PR TITLE
ch04: Fix typo

### DIFF
--- a/ch04_keys.adoc
+++ b/ch04_keys.adoc
@@ -573,7 +573,7 @@ to figure out how to use it in a transaction.  Consider the following
 output script:
 
 ----
-OP_DUP OP_HASH160 <Bob's commitment> OP_EQUAL OP_CHECKSIG
+OP_DUP OP_HASH160 <Bob's commitment> OP_EQUALVERIFY OP_CHECKSIG
 ----
 
 And also the following input script:


### PR DESCRIPTION
The P2PKH output uses the `OP_EQUALVERIFY` opcode.