### PR TITLE
ch04: Fix block header weight

### DIFF
--- a/ch06_transactions.adoc
+++ b/ch06_transactions.adoc
@@ -1143,7 +1143,7 @@ _vbytes_, where four units of weight equal one vbyte, providing an easy
 comparison to the original _byte_ measurement unit used in legacy
 Bitcoin blocks.
 
-Blocks are limited to 4 million weight.  The block header takes up 240
+Blocks are limited to 4 million weight.  The block header takes up 320
 weight.  An additional field, the transaction count, uses either 4 or
 12 weight.  All of the remaining weight may be used for transaction
 data.


### PR DESCRIPTION
The block header is 80 bytes, which equals to 320 weight.